### PR TITLE
Screen notification

### DIFF
--- a/game/src/indoor_preparation/screen_displays/shared/screen_notification.gd
+++ b/game/src/indoor_preparation/screen_displays/shared/screen_notification.gd
@@ -1,0 +1,43 @@
+class_name ScreenNotification extends Control
+
+enum ScreenNotificationType {
+    NOTIFY,
+    ERROR,
+}
+
+signal notification_expired()
+
+@onready var expiration_timer: Timer = $ExpirationTimer
+@onready var header: Label = $PC/MC/VBC/Header
+@onready var body: Label = $PC/MC/VBC/PC2/MC2/VBC2/Body
+@onready var expiration_bar: ProgressBar = $PC/MC/VBC/PC2/MC2/VBC2/ExpirationBar
+var expiration_max: float
+
+func _ready() -> void:
+    if self == get_tree().current_scene:
+        display_notification(ScreenNotificationType.NOTIFY, "This is a test notification", 3)
+
+func display_notification(notification_type: ScreenNotificationType, body_text: String,
+        duration: float) -> void:
+    # TODO: use notification type 
+    match notification_type:
+        ScreenNotificationType.NOTIFY:
+            header.text = "Notification"
+            #TODO: set theme to be normal
+        ScreenNotificationType.ERROR:
+            header.text = "ERROR"
+            #TODO: set theme to be "error" red and whatnot
+    body.text = body_text
+    expiration_max = duration
+    expiration_bar.max_value = expiration_max
+    expiration_bar.value = expiration_max
+    expiration_timer.one_shot = true
+    expiration_timer.start(duration)
+
+
+func _process(_delta: float) -> void:
+    if not expiration_timer.is_stopped():
+        expiration_bar.value = expiration_timer.time_left
+    elif visible:
+        notification_expired.emit()
+        hide()

--- a/game/src/indoor_preparation/screen_displays/shared/screen_notification.tscn
+++ b/game/src/indoor_preparation/screen_displays/shared/screen_notification.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://c657hnb6jsp15"]
+[gd_scene load_steps=3 format=3 uid="uid://cib1fq003l5jx"]
 
 [ext_resource type="Theme" uid="uid://dk5iv042psfw" path="res://assets/themes/Default.tres" id="1_4cvkc"]
+[ext_resource type="Script" path="res://src/indoor_preparation/screen_displays/shared/screen_notification.gd" id="2_hcuqa"]
 
 [node name="ScreenNotification" type="Control"]
 layout_mode = 3
@@ -12,6 +13,7 @@ anchor_bottom = 0.5
 grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_4cvkc")
+script = ExtResource("2_hcuqa")
 
 [node name="PC" type="PanelContainer" parent="."]
 layout_mode = 1
@@ -66,3 +68,4 @@ fill_mode = 1
 show_percentage = false
 
 [node name="ExpirationTimer" type="Timer" parent="."]
+one_shot = true

--- a/game/src/indoor_preparation/screen_displays/shared/screen_notification.tscn
+++ b/game/src/indoor_preparation/screen_displays/shared/screen_notification.tscn
@@ -1,0 +1,68 @@
+[gd_scene load_steps=2 format=3 uid="uid://c657hnb6jsp15"]
+
+[ext_resource type="Theme" uid="uid://dk5iv042psfw" path="res://assets/themes/Default.tres" id="1_4cvkc"]
+
+[node name="ScreenNotification" type="Control"]
+layout_mode = 3
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_4cvkc")
+
+[node name="PC" type="PanelContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -106.5
+offset_top = -28.0
+offset_right = 106.5
+offset_bottom = 28.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="MC" type="MarginContainer" parent="PC"]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="VBC" type="VBoxContainer" parent="PC/MC"]
+layout_mode = 2
+
+[node name="Header" type="Label" parent="PC/MC/VBC"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 10
+text = "Notification"
+
+[node name="PC2" type="PanelContainer" parent="PC/MC/VBC"]
+layout_mode = 2
+
+[node name="MC2" type="MarginContainer" parent="PC/MC/VBC/PC2"]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="VBC2" type="VBoxContainer" parent="PC/MC/VBC/PC2/MC2"]
+layout_mode = 2
+
+[node name="Body" type="Label" parent="PC/MC/VBC/PC2/MC2/VBC2"]
+layout_mode = 2
+text = "%s was hired successfully!"
+
+[node name="ExpirationBar" type="ProgressBar" parent="PC/MC/VBC/PC2/MC2/VBC2"]
+layout_mode = 2
+value = 50.0
+fill_mode = 1
+show_percentage = false
+
+[node name="ExpirationTimer" type="Timer" parent="."]


### PR DESCRIPTION
Implements structure and logic of "screen notification" pop-up.

Other classes (through direct call or event emission) request that a notification pops up. It'll last for the number of seconds they choose. Screens will probably dim themselves and become non-interactable during this time to help make it the clear focus. 
![image](https://github.com/user-attachments/assets/ae5cee34-35fc-480e-9de7-6ebd27ca7dd0)

As a bit of extra polish we can have it use different themes for error vs notification. Could also add icons if we want, all of that good stuff.