### PR TITLE
Upgrade details pane logic

### DIFF
--- a/game/assets/data/upgrades/001_add_2_wit2.tres
+++ b/game/assets/data/upgrades/001_add_2_wit2.tres
@@ -6,8 +6,9 @@
 [resource]
 script = ExtResource("1_y6gyi")
 name = "Study"
-description = "Wit enhanced through diligence."
-visual_summary = ""
+description = "Wit sharpened through diligence."
+visual_summary = "[center]Add:
+[img=30%]res://assets/art/HEAL_icon_64x64.png[/img]2  [img=30%]res://assets/art/HEAL_icon_64x64.png[/img]2"
 icon_ref = ExtResource("1_2j0p7")
 upgrade_type = 1
 number_of_times = 2

--- a/game/assets/data/upgrades/002_add_2_chaos2.tres
+++ b/game/assets/data/upgrades/002_add_2_chaos2.tres
@@ -7,7 +7,8 @@
 script = ExtResource("1_5rpl6")
 name = "Tinker"
 description = "One step closer to a bigger boom..."
-visual_summary = ""
+visual_summary = "[center]Add:
+[img=30%]res://assets/art/MAGIC_icon_64x64.png[/img]2  [img=30%]res://assets/art/MAGIC_icon_64x64.png[/img]2"
 icon_ref = ExtResource("1_efj53")
 upgrade_type = 1
 number_of_times = 2

--- a/game/assets/data/upgrades/003_add_2_might2.tres
+++ b/game/assets/data/upgrades/003_add_2_might2.tres
@@ -7,7 +7,8 @@
 script = ExtResource("1_fw1cs")
 name = "Combat Training"
 description = "The sims DO pay off!"
-visual_summary = ""
+visual_summary = "[center]Add:
+[img=30%]res://assets/art/ATTACK_icon_64x64.png[/img]2  [img=30%]res://assets/art/ATTACK_icon_64x64.png[/img]2"
 icon_ref = ExtResource("1_4gplk")
 upgrade_type = 1
 number_of_times = 2

--- a/game/assets/data/upgrades/003_add_2_might2.tres
+++ b/game/assets/data/upgrades/003_add_2_might2.tres
@@ -5,7 +5,7 @@
 
 [resource]
 script = ExtResource("1_fw1cs")
-name = "Combat Training"
+name = "Training Day"
 description = "The sims DO pay off!"
 visual_summary = "[center]Add:
 [img=30%]res://assets/art/ATTACK_icon_64x64.png[/img]2  [img=30%]res://assets/art/ATTACK_icon_64x64.png[/img]2"

--- a/game/assets/themes/upgrade_button_theme.tres
+++ b/game/assets/themes/upgrade_button_theme.tres
@@ -13,7 +13,7 @@
 [resource]
 Button/colors/icon_focus_color = Color(0.470588, 1, 1, 1)
 Button/colors/icon_hover_color = Color(0.836825, 0.892038, 1.15514e-06, 1)
-Button/colors/icon_pressed_color = Color(1, 0.0784314, 1, 1)
+Button/colors/icon_pressed_color = Color(0.470588, 1, 1, 1)
 Button/styles/disabled = SubResource("StyleBoxEmpty_chmng")
 Button/styles/focus = SubResource("StyleBoxEmpty_vr4vy")
 Button/styles/hover = SubResource("StyleBoxEmpty_kcygd")

--- a/game/src/characters/UpgradeChoice.gd
+++ b/game/src/characters/UpgradeChoice.gd
@@ -14,8 +14,8 @@ static var upgrade_funcs: Dictionary = {
 }
 
 @export var name: String
-@export var description: String
-@export var visual_summary: String
+@export_multiline var description: String
+@export_multiline var visual_summary: String
 @export var icon_ref: Texture2D
 
 @export var upgrade_type: UpgradeType

--- a/game/src/indoor_preparation/screen_displays/shared/character_detail/character_detail.gd
+++ b/game/src/indoor_preparation/screen_displays/shared/character_detail/character_detail.gd
@@ -3,10 +3,19 @@ class_name CharacterDetail extends Control
 @onready var database: Database = $/root/Database
 @onready var character_summary: CharacterDetailSummary = $BasicSummary
 @onready var upgrade_selection: CharacterDetailUpgrades = $UpgradeSelection
+@onready var dynamic_info_panel: DynamicInfoPanel = $DynamicInfoPanel
 @onready var character_icon: TextureRect = $IconAndCost/CharacterIcon
 @onready var exit_button: Button = $ExitButton
 
 func _ready() -> void:
+    var connect_callables: Dictionary = upgrade_selection.get_all_upgrade_button_signal_connects()
+    for connection: Callable in connect_callables["hovered"]:
+        connection.call(dynamic_info_panel.preview_upgrade_data)
+    for connection: Callable in connect_callables["selected"]:
+        connection.call(dynamic_info_panel.select_upgrade_data)
+    for connection: Callable in connect_callables["exited"]:
+        connection.call(dynamic_info_panel.stop_previewing_upgrade_data)
+
     #if self == get_tree().current_scene:
         set_character_data(database.hired_characters[0])
 

--- a/game/src/indoor_preparation/screen_displays/shared/character_detail/character_detail.tscn
+++ b/game/src/indoor_preparation/screen_displays/shared/character_detail/character_detail.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://d0wnwi5rcyku"]
+[gd_scene load_steps=10 format=3 uid="uid://d0wnwi5rcyku"]
 
 [ext_resource type="Theme" uid="uid://dk5iv042psfw" path="res://assets/themes/Default.tres" id="1_rotuw"]
 [ext_resource type="Texture2D" uid="uid://bic3i142epdt3" path="res://assets/art/placeholder_threat.png" id="2_doqwf"]
@@ -8,6 +8,7 @@
 [ext_resource type="Texture2D" uid="uid://r7a1wa1ifq57" path="res://assets/art/placeholder_close_button.png" id="4_vii54"]
 [ext_resource type="PackedScene" uid="uid://cf7gpoxw4lyd4" path="res://src/indoor_preparation/screen_displays/shared/upgrade_choice_display.tscn" id="4_vtj8y"]
 [ext_resource type="Script" path="res://src/indoor_preparation/screen_displays/shared/character_detail/character_detail_upgrades.gd" id="6_1f48f"]
+[ext_resource type="PackedScene" uid="uid://bop47lfc6joit" path="res://src/indoor_preparation/screen_displays/shared/character_detail/dynamic_info_panel.tscn" id="8_yjqcy"]
 
 [node name="CharacterDetail" type="Control"]
 layout_mode = 3
@@ -149,41 +150,8 @@ layout_mode = 2
 [node name="UpgradeChoiceDisplay5" parent="UpgradeSelection/MarginContainer/VBoxContainer" instance=ExtResource("4_vtj8y")]
 layout_mode = 2
 
-[node name="DynamicInfoPanel" type="PanelContainer" parent="."]
+[node name="DynamicInfoPanel" parent="." instance=ExtResource("8_yjqcy")]
 layout_mode = 1
-anchors_preset = -1
-anchor_left = 0.31
-anchor_top = 0.4
-anchor_right = 0.8
-anchor_bottom = 0.98
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="MarginContainer" type="MarginContainer" parent="DynamicInfoPanel"]
-layout_mode = 2
-theme_override_constants/margin_left = 5
-theme_override_constants/margin_top = 5
-theme_override_constants/margin_right = 5
-theme_override_constants/margin_bottom = 5
-
-[node name="VBoxContainer" type="VBoxContainer" parent="DynamicInfoPanel/MarginContainer"]
-layout_mode = 2
-
-[node name="Header" type="Label" parent="DynamicInfoPanel/MarginContainer/VBoxContainer"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 24
-text = "Details"
-horizontal_alignment = 1
-
-[node name="Panel" type="PanelContainer" parent="DynamicInfoPanel/MarginContainer/VBoxContainer"]
-layout_mode = 2
-size_flags_vertical = 3
-
-[node name="No Information" type="Label" parent="DynamicInfoPanel/MarginContainer/VBoxContainer/Panel"]
-layout_mode = 2
-text = "Hover or Select Icons
-For Detailed Information"
-horizontal_alignment = 1
 
 [node name="IconAndCost" type="VBoxContainer" parent="."]
 layout_mode = 1

--- a/game/src/indoor_preparation/screen_displays/shared/character_detail/character_detail.tscn
+++ b/game/src/indoor_preparation/screen_displays/shared/character_detail/character_detail.tscn
@@ -8,7 +8,7 @@
 [ext_resource type="Texture2D" uid="uid://r7a1wa1ifq57" path="res://assets/art/placeholder_close_button.png" id="4_vii54"]
 [ext_resource type="PackedScene" uid="uid://cf7gpoxw4lyd4" path="res://src/indoor_preparation/screen_displays/shared/upgrade_choice_display.tscn" id="4_vtj8y"]
 [ext_resource type="Script" path="res://src/indoor_preparation/screen_displays/shared/character_detail/character_detail_upgrades.gd" id="6_1f48f"]
-[ext_resource type="PackedScene" uid="uid://bop47lfc6joit" path="res://src/indoor_preparation/screen_displays/shared/character_detail/dynamic_info_panel.tscn" id="8_yjqcy"]
+[ext_resource type="PackedScene" uid="uid://vsu1s8qjdne8" path="res://src/indoor_preparation/screen_displays/shared/character_detail/dynamic_info_panel.tscn" id="8_yjqcy"]
 
 [node name="CharacterDetail" type="Control"]
 layout_mode = 3

--- a/game/src/indoor_preparation/screen_displays/shared/character_detail/character_detail_upgrades.gd
+++ b/game/src/indoor_preparation/screen_displays/shared/character_detail/character_detail_upgrades.gd
@@ -9,3 +9,16 @@ func set_character_data(character: Character) -> void:
             upgrade_choices[i].show()
         else:
             upgrade_choices[i].hide_upgrade_choice_info()
+
+func get_all_upgrade_button_signal_connects() -> Dictionary:
+    var result = {
+        "hovered": [],
+        "exited": [],
+        "selected": [],
+    }
+    for upgrade_choice_display in upgrade_choices:
+        result["hovered"].append(upgrade_choice_display.upgrade_hovered.connect)
+        result["exited"].append(upgrade_choice_display.upgrade_exited.connect)
+        result["selected"].append(upgrade_choice_display.upgrade_selected.connect)
+    
+    return result

--- a/game/src/indoor_preparation/screen_displays/shared/character_detail/dynamic_info_panel.gd
+++ b/game/src/indoor_preparation/screen_displays/shared/character_detail/dynamic_info_panel.gd
@@ -14,6 +14,9 @@ var selected_upgrade: UpgradeChoice
 var previewed_upgrade: UpgradeChoice
 var is_previewing: bool = false
 
+func _ready() -> void:
+    select_upgrade_data(Database._character_factories[0].upgrades[0].choices[0])
+
 func select_upgrade_data(upgrade_choice: UpgradeChoice):
     selected_upgrade = upgrade_choice
     update_display_elements()

--- a/game/src/indoor_preparation/screen_displays/shared/character_detail/dynamic_info_panel.gd
+++ b/game/src/indoor_preparation/screen_displays/shared/character_detail/dynamic_info_panel.gd
@@ -1,0 +1,47 @@
+class_name DynamicInfoPanel extends PanelContainer
+
+@onready var upgrade_details_container: Control = $MarginContainer/VBoxContainer/Panel/MarginContainer/UpgradeDetailsContainer
+@onready var upgrade_icons: Array[TextureRect] = [
+    $MarginContainer/VBoxContainer/Panel/MarginContainer/UpgradeDetailsContainer/HBoxContainer/UpgradeIcon1,
+    $MarginContainer/VBoxContainer/Panel/MarginContainer/UpgradeDetailsContainer/HBoxContainer/UpgradeIcon2
+]
+@onready var upgrade_name: Label = $MarginContainer/VBoxContainer/Panel/MarginContainer/UpgradeDetailsContainer/HBoxContainer/UpgradeName
+@onready var upgrade_description: Label = $MarginContainer/VBoxContainer/Panel/MarginContainer/UpgradeDetailsContainer/UpgradeDescription
+@onready var visual_summary: RichTextLabel = $MarginContainer/VBoxContainer/Panel/MarginContainer/UpgradeDetailsContainer/VisualSummary
+@onready var no_information: Label = $MarginContainer/VBoxContainer/Panel/MarginContainer/NoInformation
+
+var selected_upgrade: UpgradeChoice
+var previewed_upgrade: UpgradeChoice
+var is_previewing: bool = false
+
+func select_upgrade_data(upgrade_choice: UpgradeChoice):
+    selected_upgrade = upgrade_choice
+    update_display_elements()
+
+func preview_upgrade_data(upgrade_choice: UpgradeChoice):
+    previewed_upgrade = upgrade_choice
+    update_display_elements()
+
+func update_display_elements():
+    var upgrade_to_display: UpgradeChoice = selected_upgrade
+    if is_previewing and selected_upgrade != previewed_upgrade:
+        upgrade_details_container.modulate = Color(1, 1, 1, .5)
+        upgrade_to_display = previewed_upgrade
+    
+    if upgrade_to_display == null:
+        upgrade_details_container.hide()
+        no_information.show()
+    else:
+        for texture_rect: TextureRect in upgrade_icons:
+            texture_rect.texture = upgrade_to_display.icon_ref
+        upgrade_name.text = upgrade_to_display.name
+        upgrade_description.text = upgrade_to_display.description
+        visual_summary.text = upgrade_to_display.visual_summary
+
+        upgrade_details_container.show()
+        no_information.hide()
+
+func clear_upgrade_data():
+    selected_upgrade = null
+    previewed_upgrade = null
+    update_display_elements()

--- a/game/src/indoor_preparation/screen_displays/shared/character_detail/dynamic_info_panel.gd
+++ b/game/src/indoor_preparation/screen_displays/shared/character_detail/dynamic_info_panel.gd
@@ -14,15 +14,18 @@ var selected_upgrade: UpgradeChoice
 var previewed_upgrade: UpgradeChoice
 var is_previewing: bool = false
 
-func _ready() -> void:
-    select_upgrade_data(Database._character_factories[0].upgrades[0].choices[0])
-
 func select_upgrade_data(upgrade_choice: UpgradeChoice):
     selected_upgrade = upgrade_choice
     update_display_elements()
 
 func preview_upgrade_data(upgrade_choice: UpgradeChoice):
+    is_previewing = true
     previewed_upgrade = upgrade_choice
+    update_display_elements()
+
+func stop_previewing_upgrade_data(_upgrade_choice: UpgradeChoice):
+    previewed_upgrade = null
+    is_previewing = false
     update_display_elements()
 
 func update_display_elements():
@@ -30,6 +33,8 @@ func update_display_elements():
     if is_previewing and selected_upgrade != previewed_upgrade:
         upgrade_details_container.modulate = Color(1, 1, 1, .5)
         upgrade_to_display = previewed_upgrade
+    else:
+        upgrade_details_container.modulate = Color.WHITE
     
     if upgrade_to_display == null:
         upgrade_details_container.hide()

--- a/game/src/indoor_preparation/screen_displays/shared/character_detail/dynamic_info_panel.tscn
+++ b/game/src/indoor_preparation/screen_displays/shared/character_detail/dynamic_info_panel.tscn
@@ -1,0 +1,88 @@
+[gd_scene load_steps=4 format=3 uid="uid://bop47lfc6joit"]
+
+[ext_resource type="Theme" uid="uid://dk5iv042psfw" path="res://assets/themes/Default.tres" id="1_gsr3f"]
+[ext_resource type="Script" path="res://src/indoor_preparation/screen_displays/shared/character_detail/dynamic_info_panel.gd" id="1_qed3w"]
+[ext_resource type="Texture2D" uid="uid://8icadmy2cp3f" path="res://assets/art/upgrade_icon_placeholder.png" id="3_aofsp"]
+
+[node name="DynamicInfoPanel" type="PanelContainer"]
+anchors_preset = -1
+anchor_left = 0.31
+anchor_top = 0.4
+anchor_right = 0.8
+anchor_bottom = 0.98
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_gsr3f")
+script = ExtResource("1_qed3w")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+
+[node name="Header" type="Label" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+text = "Details"
+horizontal_alignment = 1
+
+[node name="Panel" type="PanelContainer" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/VBoxContainer/Panel"]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="NoInformation" type="Label" parent="MarginContainer/VBoxContainer/Panel/MarginContainer"]
+layout_mode = 2
+text = "Hover or Select Upgrades
+For Detailed Information"
+horizontal_alignment = 1
+
+[node name="UpgradeDetailsContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/Panel/MarginContainer"]
+visible = false
+layout_mode = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/Panel/MarginContainer/UpgradeDetailsContainer"]
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="UpgradeIcon1" type="TextureRect" parent="MarginContainer/VBoxContainer/Panel/MarginContainer/UpgradeDetailsContainer/HBoxContainer"]
+layout_mode = 2
+texture = ExtResource("3_aofsp")
+stretch_mode = 3
+
+[node name="UpgradeName" type="Label" parent="MarginContainer/VBoxContainer/Panel/MarginContainer/UpgradeDetailsContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 28
+text = "Study"
+
+[node name="UpgradeIcon2" type="TextureRect" parent="MarginContainer/VBoxContainer/Panel/MarginContainer/UpgradeDetailsContainer/HBoxContainer"]
+layout_mode = 2
+texture = ExtResource("3_aofsp")
+stretch_mode = 3
+
+[node name="UpgradeDescription" type="Label" parent="MarginContainer/VBoxContainer/Panel/MarginContainer/UpgradeDetailsContainer"]
+layout_mode = 2
+size_flags_horizontal = 4
+text = "Wit sharpened through diligence."
+horizontal_alignment = 1
+
+[node name="VisualSummary" type="RichTextLabel" parent="MarginContainer/VBoxContainer/Panel/MarginContainer/UpgradeDetailsContainer"]
+layout_mode = 2
+size_flags_vertical = 6
+bbcode_enabled = true
+text = "[center]Add:
+[img=30%]res://assets/art/HEAL_icon_64x64.png[/img]2  [img=30%]res://assets/art/HEAL_icon_64x64.png[/img]2
+Remove:
+[img=30%]res://assets/art/ATTACK_icon_64x64.png[/img]1"
+fit_content = true

--- a/game/src/indoor_preparation/screen_displays/shared/character_detail/dynamic_info_panel.tscn
+++ b/game/src/indoor_preparation/screen_displays/shared/character_detail/dynamic_info_panel.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3 uid="uid://bop47lfc6joit"]
+[gd_scene load_steps=4 format=3 uid="uid://vsu1s8qjdne8"]
 
 [ext_resource type="Theme" uid="uid://dk5iv042psfw" path="res://assets/themes/Default.tres" id="1_gsr3f"]
 [ext_resource type="Script" path="res://src/indoor_preparation/screen_displays/shared/character_detail/dynamic_info_panel.gd" id="1_qed3w"]

--- a/game/src/indoor_preparation/screen_displays/shared/upgrade_buttons.tres
+++ b/game/src/indoor_preparation/screen_displays/shared/upgrade_buttons.tres
@@ -1,0 +1,3 @@
+[gd_resource type="ButtonGroup" format=3 uid="uid://cqp1ir8lngdbq"]
+
+[resource]

--- a/game/src/indoor_preparation/screen_displays/shared/upgrade_choice_display.gd
+++ b/game/src/indoor_preparation/screen_displays/shared/upgrade_choice_display.gd
@@ -15,14 +15,14 @@ var upgrades: Array[UpgradeChoice]
 func _ready() -> void:
     for i in range(upgrade_buttons.size()):
         upgrade_buttons[i].connect("mouse_entered", _emit_decorated_hover.bind(i))
-        upgrade_buttons[i].connect("mouse_exited", _emit_decorated_hover.bind(i))
+        upgrade_buttons[i].connect("mouse_exited", _emit_decorated_exit.bind(i))
         upgrade_buttons[i].connect("pressed", _emit_decorated_select.bind(i))
 
 func set_upgrade_choice_data(upgrade_selector: UpgradeSelector) -> void:
     upgrades = []
     for i in range(upgrade_buttons.size()):
         upgrades.append(upgrade_selector.get_choice_data(i))
-        upgrades[i].icon = upgrades[i].icon_ref
+        upgrade_buttons[i].icon = upgrades[i].icon_ref
 
     for child in get_children():
         child.show()

--- a/game/src/indoor_preparation/screen_displays/shared/upgrade_choice_display.gd
+++ b/game/src/indoor_preparation/screen_displays/shared/upgrade_choice_display.gd
@@ -1,15 +1,41 @@
 class_name UpgradeChoiceDisplay extends PanelContainer
 
-@onready var upgrade_button_1: Button = $HBoxContainer/Button
+signal upgrade_hovered(upgrade: UpgradeChoice)
+signal upgrade_exited(upgrade: UpgradeChoice)
+signal upgrade_selected(upgrade: UpgradeChoice)
+
 @onready var or_label: Label = $HBoxContainer/Label
-@onready var upgrade_button_2: Button = $HBoxContainer/Button2
+@onready var upgrade_buttons: Array[Button] = [
+    $HBoxContainer/Button,
+    $HBoxContainer/Button2,
+]
+
+var upgrades: Array[UpgradeChoice]
+
+func _ready() -> void:
+    for i in range(upgrade_buttons.size()):
+        upgrade_buttons[i].connect("mouse_entered", _emit_decorated_hover.bind(i))
+        upgrade_buttons[i].connect("mouse_exited", _emit_decorated_hover.bind(i))
+        upgrade_buttons[i].connect("pressed", _emit_decorated_select.bind(i))
 
 func set_upgrade_choice_data(upgrade_selector: UpgradeSelector) -> void:
-    upgrade_button_1.icon = upgrade_selector.get_choice_data(0).icon_ref
-    upgrade_button_2.icon = upgrade_selector.get_choice_data(1).icon_ref
+    upgrades = []
+    for i in range(upgrade_buttons.size()):
+        upgrades.append(upgrade_selector.get_choice_data(i))
+        upgrades[i].icon = upgrades[i].icon_ref
+
     for child in get_children():
         child.show()
 
 func hide_upgrade_choice_info() -> void:
     for child in get_children():
         child.hide()
+
+func _emit_decorated_hover(button_idx: int) -> void:
+    upgrade_hovered.emit(upgrades[button_idx] if button_idx < upgrades.size() else null)
+
+func _emit_decorated_exit(button_idx: int) -> void:
+    upgrade_exited.emit(upgrades[button_idx] if button_idx < upgrades.size() else null)
+
+func _emit_decorated_select(button_idx: int) -> void:
+    upgrade_selected.emit(upgrades[button_idx] if button_idx < upgrades.size() else null)

--- a/game/src/indoor_preparation/screen_displays/shared/upgrade_choice_display.tscn
+++ b/game/src/indoor_preparation/screen_displays/shared/upgrade_choice_display.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Texture2D" uid="uid://8icadmy2cp3f" path="res://assets/art/upgrade_icon_placeholder.png" id="1_3it24"]
 [ext_resource type="Script" path="res://src/indoor_preparation/screen_displays/shared/upgrade_choice_display.gd" id="1_i8aii"]
 [ext_resource type="Theme" uid="uid://c34dsuakeic5x" path="res://assets/themes/upgrade_button_theme.tres" id="2_d8k51"]
-[ext_resource type="ButtonGroup" uid="uid://cqp1ir8lngdbq" path="res://src/indoor_preparation/screen_displays/shared/upgrade_buttons.tres" id="3_7pgfm"]
+[ext_resource type="ButtonGroup" path="res://src/indoor_preparation/screen_displays/shared/upgrade_buttons.tres" id="3_7pgfm"]
 
 [node name="UpgradeChoiceDisplay" type="PanelContainer"]
 offset_right = 101.0

--- a/game/src/indoor_preparation/screen_displays/shared/upgrade_choice_display.tscn
+++ b/game/src/indoor_preparation/screen_displays/shared/upgrade_choice_display.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://cf7gpoxw4lyd4"]
+[gd_scene load_steps=5 format=3 uid="uid://cf7gpoxw4lyd4"]
 
 [ext_resource type="Texture2D" uid="uid://8icadmy2cp3f" path="res://assets/art/upgrade_icon_placeholder.png" id="1_3it24"]
 [ext_resource type="Script" path="res://src/indoor_preparation/screen_displays/shared/upgrade_choice_display.gd" id="1_i8aii"]
 [ext_resource type="Theme" uid="uid://c34dsuakeic5x" path="res://assets/themes/upgrade_button_theme.tres" id="2_d8k51"]
+[ext_resource type="ButtonGroup" uid="uid://cqp1ir8lngdbq" path="res://src/indoor_preparation/screen_displays/shared/upgrade_buttons.tres" id="3_7pgfm"]
 
 [node name="UpgradeChoiceDisplay" type="PanelContainer"]
 offset_right = 101.0
@@ -20,6 +21,8 @@ theme_override_constants/separation = 10
 [node name="Button" type="Button" parent="HBoxContainer"]
 layout_mode = 2
 theme = ExtResource("2_d8k51")
+toggle_mode = true
+button_group = ExtResource("3_7pgfm")
 icon = ExtResource("1_3it24")
 flat = true
 
@@ -30,5 +33,7 @@ text = "or"
 [node name="Button2" type="Button" parent="HBoxContainer"]
 layout_mode = 2
 theme = ExtResource("2_d8k51")
+toggle_mode = true
+button_group = ExtResource("3_7pgfm")
 icon = ExtResource("1_3it24")
 flat = true


### PR DESCRIPTION
Made the details pane automatically reflect the information about upgrades when they're hovered or selected

Buy panel isn't wired up for logic yet, neither is the X. They'll be coming soon!

Hovering:
![image](https://github.com/user-attachments/assets/61a49dda-7db8-4df2-bb83-2cab834c1231)
Selected:
![image](https://github.com/user-attachments/assets/599833b9-8184-47f7-9def-cbb315fd1e53)
Hovering different than selected:
![image](https://github.com/user-attachments/assets/4560c8c6-4025-483c-9f5c-164d1038d9a5)
