### PR TITLE
Differentiate hire and upgrade

### DIFF
--- a/game/src/indoor_preparation/screen.gd
+++ b/game/src/indoor_preparation/screen.gd
@@ -69,6 +69,7 @@ func _applicant_selected_from_hiring_preview(character: Character) -> void:
 
 func _on_crew_member_selected(character: Character) -> void:
     _hide_all_screen_displays()
+    _cancel_notifications()
     current_view = ScreenViews.CREW_MEMBER_DETAIL
     character_detail_display.set_character_data(character)
     _delay_callback(character_detail_display.show)
@@ -110,6 +111,9 @@ func _on_hiring_failure(character: Character, reason: String) -> void:
         HIRE_FAIL_FORMAT % [character.name, reason],
         HIRE_FAIL_DURATION
     )
+    screen_notification.notification_expired.connect(
+        hire_detail_display.set_character_data.bind(character),
+        CONNECT_ONE_SHOT)
 
 func _on_upgrade_success(character: Character):
     character_detail_display.refresh_upgrade_view()

--- a/game/src/indoor_preparation/screen_displays/crew_member_detail/crew_member_detail.tscn
+++ b/game/src/indoor_preparation/screen_displays/crew_member_detail/crew_member_detail.tscn
@@ -9,3 +9,6 @@ script = ExtResource("2_47e65")
 
 [node name="UpgradePrompt" parent="IconAndCost" index="1" instance=ExtResource("2_wa450")]
 layout_mode = 2
+
+[node name="OptionalHeader" parent="." index="5"]
+visible = false

--- a/game/src/indoor_preparation/screen_displays/shared/character_detail/character_detail.tscn
+++ b/game/src/indoor_preparation/screen_displays/shared/character_detail/character_detail.tscn
@@ -181,3 +181,10 @@ offset_left = -32.0
 offset_bottom = 32.0
 grow_horizontal = 0
 icon = ExtResource("4_vii54")
+
+[node name="OptionalHeader" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.3
+anchor_right = 0.3
+text = "For Hire:"


### PR DESCRIPTION
Also snuck in a little bug fix for when you fail to hire someone
here's the new difference:

crew member view (already hired):
![image](https://github.com/user-attachments/assets/0822a64e-ce25-4888-b812-ac598ddf60f2)
hiring view:
![image](https://github.com/user-attachments/assets/65d71e57-6385-4adf-8cb9-875bec737f31)

Maybe it's not too helpful, but at least there's some kinda silhouette change. Might also be able to improve visual clarity with different background colors / textures.