### PR TITLE
add zoom effect to enter / exit.

### DIFF
--- a/game/src/gameplay/Gameplay.tscn
+++ b/game/src/gameplay/Gameplay.tscn
@@ -18,16 +18,36 @@ theme = ExtResource("1_hbifn")
 script = ExtResource("1_exjrn")
 
 [node name="OutdoorBattleMode" type="CanvasLayer" parent="."]
+offset = Vector2(640, 360)
+transform = Transform2D(1, 0, 0, 1, 640, 360)
 
 [node name="BattlefieldOutdoors" parent="OutdoorBattleMode" instance=ExtResource("2_35wcq")]
+offset_left = -640.0
+offset_top = -360.0
+offset_right = -640.0
+offset_bottom = -360.0
 
 [node name="BackToStartMenuButton" parent="OutdoorBattleMode" instance=ExtResource("1_8sw2a")]
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -640.0
+offset_top = -360.0
+offset_right = -640.0
+offset_bottom = -360.0
+grow_horizontal = 0
 
 [node name="IndoorPrepMode" type="CanvasLayer" parent="."]
 layer = 2
 visible = false
+offset = Vector2(640, 360)
+transform = Transform2D(1, 0, 0, 1, 640, 360)
 
 [node name="IndoorPreparation" parent="IndoorPrepMode" instance=ExtResource("4_qkdrp")]
+offset_left = -640.0
+offset_top = -360.0
+offset_right = -640.0
+offset_bottom = -360.0
 
 [node name="TransitionCover" type="CanvasLayer" parent="."]
 layer = 3

--- a/game/src/gameplay/gameplay.gd
+++ b/game/src/gameplay/gameplay.gd
@@ -33,6 +33,11 @@ func go_inside() -> void:
     # if we had more complex states (we wanted to make sure real-time events didn't
     # happen until the fade in was completely done) we could add more callbacks to 
     # different parts of the process.
+    var zoom_in_tween = create_tween()
+    zoom_in_tween.set_ease(Tween.EASE_OUT)
+    zoom_in_tween.set_trans(Tween.TRANS_CUBIC)
+    zoom_in_tween.tween_property(outdoor_canvas, "scale", Vector2.ONE * 2, .5)
+    zoom_in_tween.tween_property(outdoor_canvas, "scale", Vector2.ONE, .25)
 
 func go_outside() -> void:
     # see go_inside, same idea here
@@ -45,3 +50,9 @@ func go_outside() -> void:
     mode_transition_cover.hide()
     transition_cover.show()
     mode_transition_cover.fade_in_out(transition_while_hidden)
+
+    var zoom_out_tween = create_tween()
+    zoom_out_tween.set_ease(Tween.EASE_OUT)
+    zoom_out_tween.set_trans(Tween.TRANS_CUBIC)
+    zoom_out_tween.tween_property(indoor_canvas, "scale", Vector2.ONE * .9, .5)
+    zoom_out_tween.tween_property(indoor_canvas, "scale", Vector2.ONE, .25)

--- a/game/src/transition_cover/mode_transition_cover.gd
+++ b/game/src/transition_cover/mode_transition_cover.gd
@@ -27,6 +27,7 @@ func _apply_fade_in_tween_steps(tween: Tween) -> Tween:
     tween.set_trans(Tween.TransitionType.TRANS_CUBIC)
     tween.tween_property(self, "modulate", Color.TRANSPARENT, .1)
     tween.tween_callback(show)
+    tween.tween_interval(TRANSITION_DURATION)
     tween.tween_property(self, "modulate", Color.WHITE, TRANSITION_DURATION)
     return tween
 
@@ -34,6 +35,7 @@ func _apply_fade_out_tween_steps(tween: Tween) -> Tween:
     tween.set_ease(Tween.EaseType.EASE_IN)
     tween.set_trans(Tween.TransitionType.TRANS_CUBIC)
     tween.tween_property(self, "modulate", Color.WHITE, .1)
+    tween.tween_interval(TRANSITION_DURATION)
     tween.tween_property(self, "modulate", Color.TRANSPARENT, TRANSITION_DURATION)
     tween.tween_callback(hide)
     return tween

--- a/game/src/transition_cover/mode_transition_cover.tscn
+++ b/game/src/transition_cover/mode_transition_cover.tscn
@@ -12,6 +12,7 @@ color = Color(0, 0, 0, 1)
 script = ExtResource("1_5is58")
 
 [node name="Label" type="Label" parent="."]
+visible = false
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5


### PR DESCRIPTION
It's implemented in a bit of a hacky way - if we want to change the coordinates the zoom focuses on we have to change the offset & position of the canvas, since scale always moves in at its 0,0. Not a biggie, but just know that some values may look wonky in gameplay if you look closely

It's probably not actually that hacky - the fact everything operates on different coordinate systems is painful (as far as I understand it) no matter how we deal with it. It's functional and stable, so I think that's all we care about.