### PR TITLE
Reroll display

### DIFF
--- a/game/assets/data/database.gd
+++ b/game/assets/data/database.gd
@@ -3,7 +3,7 @@ extends Node
 
 signal money_changed(new_value: int, old_value: int)
 signal fuel_changed(new_value: int, old_value: int)
-signal die_slots_set(new_value: Array[CharacterDieSlot])
+signal die_slots_set(was_reroll: bool)
 signal die_slot_changed(changed_die_slot: CharacterDieSlot)
 
 enum StatType {
@@ -204,10 +204,11 @@ func set_current_barrier_data(updated_barrier_data: BarrierData) -> void:
     current_barrier_data = updated_barrier_data
 
 func set_current_character_die_slots(
-    updated_slots: Array[CharacterDieSlot]
+    updated_slots: Array[CharacterDieSlot],
+    was_reroll: bool = false
 ) -> void:
     current_character_die_slots = updated_slots
-    die_slots_set.emit()
+    die_slots_set.emit(was_reroll)
 
 func set_current_matching_stat_type_multiplier(updated_number: int) -> void:
     current_matching_stat_type_multiplier = updated_number

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=3 uid="uid://b6k6baalu42w7"]
+[gd_scene load_steps=19 format=3 uid="uid://b6k6baalu42w7"]
 
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd" id="1_3j823"]
 [ext_resource type="PackedScene" uid="uid://da57hkojchohp" path="res://src/shared_ui/resource_display/health_display.tscn" id="2_6fssr"]
@@ -13,6 +13,7 @@
 [ext_resource type="PackedScene" uid="uid://cg02ahrm1dodf" path="res://src/battlefield_outdoors/combat_math_calculations_hud/CombatMathCalculationsHud.tscn" id="6_30blh"]
 [ext_resource type="PackedScene" uid="uid://dr7v1vu064ukv" path="res://src/shared_ui/character_action_display/character_action_display.tscn" id="6_ihvc6"]
 [ext_resource type="Texture2D" uid="uid://c812lqrvhyq01" path="res://assets/art/ATTACK_icon_64x64.png" id="6_r4yqa"]
+[ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/reroll_button.gd" id="7_xg4o8"]
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/total_power_display.gd" id="9_cb4ss"]
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/barrier_preview.gd" id="9_iui7q"]
 [ext_resource type="PackedScene" uid="uid://vnu6f53bf3ur" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/character_info_panel.tscn" id="16_oou66"]
@@ -173,6 +174,7 @@ size_flags_horizontal = 4
 size_flags_vertical = 8
 text = "Reroll
 (Costs 1 Fuel)"
+script = ExtResource("7_xg4o8")
 
 [node name="FuelDisplayMini" parent="BottomInfoDisplay/Center/TopEdge" instance=ExtResource("5_3m24g")]
 layout_mode = 1

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn
@@ -157,7 +157,7 @@ layout_mode = 2
 text = "Status
 "
 
-[node name="MockRerollButton" type="Button" parent="BottomInfoDisplay/Center/TopEdge"]
+[node name="RerollButton" type="Button" parent="BottomInfoDisplay/Center/TopEdge"]
 layout_mode = 1
 anchors_preset = 7
 anchor_left = 0.5
@@ -501,5 +501,5 @@ offset_right = 0.0
 offset_bottom = 0.0
 grow_vertical = 0
 
-[connection signal="pressed" from="BottomInfoDisplay/Center/TopEdge/MockRerollButton" to="." method="_on_mock_reroll_button_pressed"]
+[connection signal="pressed" from="BottomInfoDisplay/Center/TopEdge/RerollButton" to="." method="_on_mock_reroll_button_pressed"]
 [connection signal="pressed" from="BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay/PanelContainer/VBoxContainer/MockAttackButton" to="." method="_on_mock_attack_button_pressed"]

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
@@ -28,6 +28,7 @@ const REROLL_FAIL_DURATION = 2
 @onready var calculations_hud: CombatMathCalculationsHud = $BottomInfoDisplay/Center/CrewStatus/StatusSections/CalculationsDisplay/CombatMathCalculationsHud
 @onready var barrier_preview: BarrierPreview = $BottomInfoDisplay/Right/BarrierPreview
 @onready var total_power_display: TotalPowerDisplay = $BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay
+@onready var reroll_button: Button = $BottomInfoDisplay/Center/TopEdge/RerollButton
 
 func _ready():
     _hide_warnings()
@@ -45,6 +46,9 @@ func _ready():
     character_info_panel.character_selected.connect(crew_member_selector._on_character_selected)
     character_info_panel.character_selected.connect(crew_actions_display._on_character_selected)
 
+    reroll_button.mouse_entered.connect(crew_actions_display._start_preview_reroll)
+    reroll_button.mouse_exited.connect(crew_actions_display._stop_preview_reroll)
+ 
     barrier_strength_scaled.connect(calculations_hud.refresh)
     barrier_strength_scaled.connect(barrier_preview.refresh)
     barrier_strength_scaled.connect(total_power_display.refresh)

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
@@ -28,7 +28,7 @@ const REROLL_FAIL_DURATION = 2
 @onready var calculations_hud: CombatMathCalculationsHud = $BottomInfoDisplay/Center/CrewStatus/StatusSections/CalculationsDisplay/CombatMathCalculationsHud
 @onready var barrier_preview: BarrierPreview = $BottomInfoDisplay/Right/BarrierPreview
 @onready var total_power_display: TotalPowerDisplay = $BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay
-@onready var reroll_button: Button = $BottomInfoDisplay/Center/TopEdge/RerollButton
+@onready var reroll_button: RerollButton = $BottomInfoDisplay/Center/TopEdge/RerollButton
 
 func _ready():
     _hide_warnings()
@@ -46,8 +46,8 @@ func _ready():
     character_info_panel.character_selected.connect(crew_member_selector._on_character_selected)
     character_info_panel.character_selected.connect(crew_actions_display._on_character_selected)
 
-    reroll_button.mouse_entered.connect(crew_actions_display._start_preview_reroll)
-    reroll_button.mouse_exited.connect(crew_actions_display._stop_preview_reroll)
+    reroll_button.hovered_available_reroll.connect(crew_actions_display._start_preview_reroll)
+    reroll_button.exited_available_reroll.connect(crew_actions_display._stop_preview_reroll)
  
     barrier_strength_scaled.connect(calculations_hud.refresh)
     barrier_strength_scaled.connect(barrier_preview.refresh)

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_actions_display.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_actions_display.gd
@@ -22,7 +22,15 @@ func _on_character_selected(selected_character: Character, button_end_state: boo
         if button_end_state:
             action_display.button.button_pressed = (
                 action_display.character_die_slot != null
-                and action_display.character_die_slot.character == selected_character 
+                and action_display.character_die_slot.character == selected_character
             )
         else:
             action_display.button.button_pressed = false
+
+func _start_preview_reroll() -> void:
+    for action_display in action_displays:
+        action_display.set_rolling_display(true)
+
+func _stop_preview_reroll() -> void:
+    for action_display in action_displays:
+        action_display.set_rolling_display(false)

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_actions_display.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_actions_display.gd
@@ -7,12 +7,13 @@ func _ready() -> void:
     refresh()
     database.die_slots_set.connect(refresh)
 
-func refresh():
-    var die_slots = database.current_character_die_slots
+func refresh(was_reroll: bool = false):
+    var die_slots: Array[CharacterDieSlot] = database.current_character_die_slots
 
     for i in action_displays.size():
         if i < die_slots.size():
-            action_displays[i].set_character_die_slot(die_slots[i])
+            var display_particles: bool = was_reroll and not die_slots[i].is_frozen
+            action_displays[i].set_character_die_slot(die_slots[i], display_particles)
         else:
             action_displays[i].set_character_die_slot(null)
         action_displays[i].button.button_pressed = false

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/reroll_button.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/reroll_button.gd
@@ -1,0 +1,39 @@
+class_name RerollButton extends Button
+
+signal hovered_available_reroll
+signal exited_available_reroll
+
+const REROLL_COOLDOWN: float = 1.0
+
+func _ready() -> void:
+    mouse_entered.connect(_on_mouse_entered)
+    mouse_exited.connect(_on_mouse_exited)
+    pressed.connect(_on_pressed)
+
+func _set_disabled(new_value: bool):
+    disabled = new_value
+    _on_disabled_changed()
+
+func _on_mouse_entered():
+    if not disabled:
+        hovered_available_reroll.emit()
+
+func _on_mouse_exited():
+    if not disabled:
+        exited_available_reroll.emit()
+
+func _on_disabled_changed():
+    if disabled and is_hovered():
+        exited_available_reroll.emit()
+    elif not disabled and is_hovered():
+        hovered_available_reroll.emit()
+
+func _on_pressed():
+    _set_disabled(true)
+    var cooldown_tween = create_tween()
+    cooldown_tween.tween_callback(_on_cooldown_complete).set_delay(REROLL_COOLDOWN)
+
+func _on_cooldown_complete():
+    _set_disabled(false)
+    if is_hovered():
+        mouse_entered.emit()

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/reroll_button.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/reroll_button.gd
@@ -3,7 +3,7 @@ class_name RerollButton extends Button
 signal hovered_available_reroll
 signal exited_available_reroll
 
-const REROLL_COOLDOWN: float = 1.0
+@export var reroll_cooldown: float = 1.5
 
 func _ready() -> void:
     mouse_entered.connect(_on_mouse_entered)
@@ -31,7 +31,7 @@ func _on_disabled_changed():
 func _on_pressed():
     _set_disabled(true)
     var cooldown_tween = create_tween()
-    cooldown_tween.tween_callback(_on_cooldown_complete).set_delay(REROLL_COOLDOWN)
+    cooldown_tween.tween_callback(_on_cooldown_complete).set_delay(reroll_cooldown)
 
 func _on_cooldown_complete():
     _set_disabled(false)

--- a/game/src/battlefield_outdoors/grid_of_dice_results/grid_of_dice_results.gd
+++ b/game/src/battlefield_outdoors/grid_of_dice_results/grid_of_dice_results.gd
@@ -34,4 +34,4 @@ func roll_dice() -> void:
             character_die_slot.last_roll_result
         )
 
-    Database.set_current_character_die_slots(character_die_slots)
+    Database.set_current_character_die_slots(character_die_slots, true)

--- a/game/src/shared_ui/character_action_display/character_action_display.gd
+++ b/game/src/shared_ui/character_action_display/character_action_display.gd
@@ -55,10 +55,11 @@ func _on_die_slot_update(changed_die_slot: CharacterDieSlot) -> void:
         refresh()
 
 func _process(_delta: float):
-    if rolling_display and character_die_slot != null:
+    if rolling_display and character_die_slot != null and not character_die_slot.is_frozen:
         _set_up_rolling_tween()
 
-    if not rolling_display and (rolling_tween != null and rolling_tween.is_running()):
+    if ((not rolling_display or (character_die_slot != null and character_die_slot.is_frozen))
+            and (rolling_tween != null and rolling_tween.is_running())):
         rolling_tween.stop()
         refresh()
 
@@ -74,3 +75,6 @@ func _cycle_die_result_display(rand_value: float) -> void:
     var actions: Array[Action] = character_die_slot.character.actions.get_all()
     var action_index: int = ceil(rand_value * actions.size()) - 1
     die_result.set_action(actions[action_index])
+
+func set_rolling_display(new_rolling_display: bool):
+    rolling_display = new_rolling_display

--- a/game/src/shared_ui/character_action_display/character_action_display.gd
+++ b/game/src/shared_ui/character_action_display/character_action_display.gd
@@ -6,6 +6,7 @@ signal character_selected(character: Character, button_end_state: bool)
 @onready var frozen_background: Control = $FrozenBackground
 @onready var frozen_icon: TextureRect = $FrozenIcon
 @onready var button: Button = $Button
+@onready var value_changed_particles: CPUParticles2D = $Control/ValueChangedParticles
 
 var character_die_slot: CharacterDieSlot
 
@@ -17,8 +18,11 @@ func _ready() -> void:
     button.pressed.connect(_on_button_pressed)
     Database.die_slot_changed.connect(_on_die_slot_update)
 
-func refresh() -> void:
+func refresh(trigger_particles: bool = false) -> void:
     if character_die_slot != null:
+        if trigger_particles:
+            value_changed_particles.restart()
+
         texture = character_die_slot.character.icon
         die_result.set_action(character_die_slot.last_roll_result)
         show()
@@ -31,10 +35,9 @@ func refresh() -> void:
     else:
         hide()
 
-
-func set_character_die_slot(new_die_slot: CharacterDieSlot) -> void:
+func set_character_die_slot(new_die_slot: CharacterDieSlot, display_particles: bool = false) -> void:
     character_die_slot = new_die_slot
-    refresh()
+    refresh(display_particles)
 
 func toggle_freeze() -> void:
     Database.set_die_slot_frozen_status(

--- a/game/src/shared_ui/character_action_display/character_action_display.gd
+++ b/game/src/shared_ui/character_action_display/character_action_display.gd
@@ -2,13 +2,15 @@ class_name CharacterActionDisplay extends TextureRect
 
 signal character_selected(character: Character, button_end_state: bool)
 
-
 @onready var die_result: DieResult = $DieResult
 @onready var frozen_background: Control = $FrozenBackground
 @onready var frozen_icon: TextureRect = $FrozenIcon
 @onready var button: Button = $Button
 
 var character_die_slot: CharacterDieSlot
+
+var rolling_display: bool
+var rolling_tween: Tween
 
 func _ready() -> void:
     button.gui_input.connect(_handle_freeze_roll_action)
@@ -51,3 +53,24 @@ func _on_button_pressed() -> void:
 func _on_die_slot_update(changed_die_slot: CharacterDieSlot) -> void:
     if changed_die_slot == character_die_slot:
         refresh()
+
+func _process(_delta: float):
+    if rolling_display and character_die_slot != null:
+        _set_up_rolling_tween()
+
+    if not rolling_display and (rolling_tween != null and rolling_tween.is_running()):
+        rolling_tween.stop()
+        refresh()
+
+func _set_up_rolling_tween():
+    if rolling_tween == null or not rolling_tween.is_valid():
+        rolling_tween = create_tween()
+        rolling_tween.set_loops()
+        rolling_tween.tween_method(_cycle_die_result_display, 0.0, 1.0, .5)
+    elif not rolling_tween.is_running():
+        rolling_tween.play()
+
+func _cycle_die_result_display(rand_value: float) -> void:
+    var actions: Array[Action] = character_die_slot.character.actions.get_all()
+    var action_index: int = ceil(rand_value * actions.size()) - 1
+    die_result.set_action(actions[action_index])

--- a/game/src/shared_ui/character_action_display/character_action_display.tscn
+++ b/game/src/shared_ui/character_action_display/character_action_display.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://dr7v1vu064ukv"]
+[gd_scene load_steps=11 format=3 uid="uid://dr7v1vu064ukv"]
 
 [ext_resource type="Script" path="res://src/shared_ui/character_action_display/character_action_display.gd" id="2_11qdl"]
 [ext_resource type="PackedScene" uid="uid://lw7wcqkoqifj" path="res://src/shared_ui/die_result/DieResult.tscn" id="2_lvo8c"]
@@ -7,6 +7,10 @@
 [ext_resource type="Texture2D" uid="uid://4nvogy60mpq3" path="res://icon.svg" id="3_sibwu"]
 [ext_resource type="StyleBox" uid="uid://218yva3nynfq" path="res://assets/themes/style_boxes/yellow_glow_stylebox.tres" id="4_i8af1"]
 [ext_resource type="Texture2D" uid="uid://c8dsnvyqbn3fh" path="res://assets/art/lock_icon.png" id="4_mbq58"]
+
+[sub_resource type="Curve" id="Curve_vcnhl"]
+_data = [Vector2(0.0353698, 0.190629), 0.0, 0.0, 0, 0, Vector2(0.234727, 0.908216), 0.0, 0.0, 0, 0, Vector2(1, 0), 0.0, 0.0, 0, 0]
+point_count = 3
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_xrpyl"]
 draw_center = false
@@ -35,6 +39,30 @@ grow_vertical = 2
 texture = ExtResource("3_sibwu")
 expand_mode = 2
 script = ExtResource("2_11qdl")
+
+[node name="Control" type="Control" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="ValueChangedParticles" type="CPUParticles2D" parent="Control"]
+emitting = false
+amount = 20
+one_shot = true
+explosiveness = 0.5
+emission_shape = 3
+emission_rect_extents = Vector2(32, 32)
+gravity = Vector2(0, 0)
+angular_velocity_min = -50.0
+angular_velocity_max = 50.0
+scale_amount_min = 2.0
+scale_amount_max = 6.0
+scale_amount_curve = SubResource("Curve_vcnhl")
 
 [node name="FrozenBackground" type="Panel" parent="."]
 visible = false


### PR DESCRIPTION
There are now visual effects around the re-rolling process. 

The game communicates that values will shuffle when the reroll button is hovered, and it gives some visual feedback when the reroll is complete to focus the player's attention on the values that changed.

![image](https://github.com/user-attachments/assets/9ad6f3be-0c30-4cf3-935b-b4cdcc5a1414)

Notably, this doesn't mess with the way "calculations" or "total" displays handle their numbers.

We could add extra visual flair there too, but this seemed like a good stopping spot for some basic reroll communication.

big note, this still all resolves in one moment so there's no sequence to resolving the roll information. Having timing to reveal each changed value and an updated total could be good, but let's confirm its needed first.