### PR TITLE
Hud charge sequence

### DIFF
--- a/game/src/battlefield_outdoors/battlefield_outdoors.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors.gd
@@ -31,6 +31,10 @@ func transition_in() -> void:
     battlefield_outdoors_hud.crew_member_selector.refresh()
     battlefield_outdoors_hud.refresh_calculations()
     battlefield_outdoors_hud.character_info_panel.display_character(null)
+    battlefield_outdoors_hud._enable_interaction()
+
+func transition_out() -> void:
+    battlefield_outdoors_hud._disable_interaction()
 
 func _begin_charge_sequence() -> void:
     if charge_sequence_tween != null and charge_sequence_tween.is_running():

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
@@ -31,6 +31,7 @@ const REROLL_FAIL_DURATION = 2
 @onready var total_power_display: TotalPowerDisplay = $BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay
 @onready var reroll_button: RerollButton = $BottomInfoDisplay/Center/TopEdge/RerollButton
 @onready var charge_button: Button = $BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay/PanelContainer/VBoxContainer/ChargeButton
+@onready var go_inside_button: Button = $GoInsideButton
 
 func _ready():
     _hide_warnings()
@@ -191,9 +192,25 @@ func _on_character_selection_changed(character: Character, selected_state: bool)
     else:
         character_info_panel.display_character(null)
 
+func _disable_interaction() -> void:
+    reroll_button.disabled = true
+    charge_button.disabled = true
+    go_inside_button.disabled = true
+    # implement "turn off" actions here
+    crew_actions_display.disable_all()
+    crew_member_selector.disable_all()
+
+func _enable_interaction() -> void:
+    reroll_button.disabled = false
+    charge_button.disabled = false
+    go_inside_button.disabled = false
+    # fade in hud, more quickly this time
+    crew_actions_display.enable_all()
+    crew_member_selector.enable_all()
+
 func _on_charge_start() -> void:
     print("HUD charge start")
-    # Disable buttons right away
+    _disable_interaction()
     # fade out HUD over the course of a while
 
 func _on_charge_warmup(duration: float) -> void:
@@ -210,5 +227,4 @@ func _on_charge_cooldown(duration: float) -> void:
     # trigger refreshes & information updates
 
 func _on_charge_finish() -> void:
-    print("HUD charge finish")
-    # fade in hud, more quickly this time
+    _enable_interaction()

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
@@ -21,6 +21,7 @@ const REROLL_FAIL_DURATION = 2
     $CentralControls/VBoxContainer/Warnings/WarningOutOfTroops
 )
 @onready var bottom_info_display: Control = $BottomInfoDisplay
+@onready var top_bar_display: Control = $TopBar
 @onready var screen_notification: ScreenNotification = $ScreenNotification
 @onready var character_info_panel: CharacterInfoPanel = $CharacterInfoPanel
 @onready var crew_member_selector: CrewMemberSelector = $BottomInfoDisplay/Left/CrewMemberSelector
@@ -207,6 +208,7 @@ func _charge_mode_fadeout(duration: float) -> void:
         bottom_info_display,
         screen_notification,
         go_inside_button,
+        top_bar_display,
     ]
     for target: Control in fadeout_targets:
         create_tween().tween_property(target, "modulate", Color.TRANSPARENT, duration)
@@ -216,6 +218,7 @@ func _charge_mode_fadein(duration: float) -> void:
         bottom_info_display,
         screen_notification,
         go_inside_button,
+        top_bar_display,
     ]
     for target: Control in fadein_targets:
         create_tween().tween_property(target, "modulate", Color.WHITE, duration)

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
@@ -193,6 +193,8 @@ func _on_character_selection_changed(character: Character, selected_state: bool)
 
 func _on_charge_start() -> void:
     print("HUD charge start")
+    # Disable buttons right away
+    # fade out HUD over the course of a while
 
 func _on_charge_warmup(duration: float) -> void:
     print("HUD charge warmup", duration)
@@ -205,6 +207,8 @@ func _on_charge_impact(duration: float) -> void:
 
 func _on_charge_cooldown(duration: float) -> void:
     print("HUD charge cooldown", duration)
+    # trigger refreshes & information updates
 
 func _on_charge_finish() -> void:
     print("HUD charge finish")
+    # fade in hud, more quickly this time

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
@@ -193,7 +193,7 @@ func _on_character_selection_changed(character: Character, selected_state: bool)
         character_info_panel.display_character(null)
 
 func _disable_interaction() -> void:
-    reroll_button.disabled = true
+    reroll_button._set_disabled(true)
     charge_button.disabled = true
     go_inside_button.disabled = true
     # implement "turn off" actions here
@@ -201,7 +201,7 @@ func _disable_interaction() -> void:
     crew_member_selector.disable_all()
 
 func _enable_interaction() -> void:
-    reroll_button.disabled = false
+    reroll_button._set_disabled(false)
     charge_button.disabled = false
     go_inside_button.disabled = false
     # fade in hud, more quickly this time

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
@@ -199,6 +199,7 @@ func _disable_interaction() -> void:
     # implement "turn off" actions here
     crew_actions_display.disable_all()
     crew_member_selector.disable_all()
+    character_info_panel.display_character(null)
 
 func _enable_interaction() -> void:
     reroll_button._set_disabled(false)

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
@@ -20,6 +20,7 @@ const REROLL_FAIL_DURATION = 2
 @onready var warning_out_of_troops = (
     $CentralControls/VBoxContainer/Warnings/WarningOutOfTroops
 )
+@onready var bottom_info_display: Control = $BottomInfoDisplay
 @onready var screen_notification: ScreenNotification = $ScreenNotification
 @onready var character_info_panel: CharacterInfoPanel = $CharacterInfoPanel
 @onready var crew_member_selector: CrewMemberSelector = $BottomInfoDisplay/Left/CrewMemberSelector
@@ -201,6 +202,24 @@ func _disable_interaction() -> void:
     crew_member_selector.disable_all()
     character_info_panel.display_character(null)
 
+func _charge_mode_fadeout(duration: float) -> void:
+    var fadeout_targets: Array[Control] = [
+        bottom_info_display,
+        screen_notification,
+        go_inside_button,
+    ]
+    for target: Control in fadeout_targets:
+        create_tween().tween_property(target, "modulate", Color.TRANSPARENT, duration)
+    
+func _charge_mode_fadein(duration: float) -> void:
+    var fadein_targets: Array[Control] = [
+        bottom_info_display,
+        screen_notification,
+        go_inside_button,
+    ]
+    for target: Control in fadein_targets:
+        create_tween().tween_property(target, "modulate", Color.WHITE, duration)
+
 func _enable_interaction() -> void:
     reroll_button._set_disabled(false)
     charge_button.disabled = false
@@ -212,20 +231,22 @@ func _enable_interaction() -> void:
 func _on_charge_start() -> void:
     print("HUD charge start")
     _disable_interaction()
-    # fade out HUD over the course of a while
 
 func _on_charge_warmup(duration: float) -> void:
     print("HUD charge warmup", duration)
+    _charge_mode_fadeout(duration)
 
 func _on_charge_action(duration: float) -> void:
     print("HUD charge action", duration)
 
 func _on_charge_impact(duration: float) -> void:
     print("HUD charge impact", duration)
+    # health reduced
 
 func _on_charge_cooldown(duration: float) -> void:
     print("HUD charge cooldown", duration)
     # trigger refreshes & information updates
+    _charge_mode_fadein(duration)
 
 func _on_charge_finish() -> void:
     _enable_interaction()

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_actions_display.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_actions_display.gd
@@ -38,6 +38,7 @@ func _stop_preview_reroll() -> void:
 
 func disable_all() -> void:
     for action_display in action_displays:
+        action_display.button.button_pressed = false
         action_display.disable()
 
 func enable_all() -> void:

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_actions_display.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_actions_display.gd
@@ -35,3 +35,11 @@ func _start_preview_reroll() -> void:
 func _stop_preview_reroll() -> void:
     for action_display in action_displays:
         action_display.set_rolling_display(false)
+
+func disable_all() -> void:
+    for action_display in action_displays:
+        action_display.disable()
+
+func enable_all() -> void:
+    for action_display in action_displays:
+        action_display.enable()

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_selector/crew_member_selector.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_selector/crew_member_selector.gd
@@ -21,3 +21,11 @@ func _on_character_selected(selected_character: Character, button_end_state: boo
             crew_selector_button.button.button_pressed = crew_selector_button.character == selected_character
         else:
             crew_selector_button.button.button_pressed = false
+
+func disable_all() -> void:
+    for crew_selector in crew_selector_buttons:
+        crew_selector.disable()
+
+func enable_all() -> void:
+    for crew_selector in crew_selector_buttons:
+        crew_selector.enable()

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_selector/crew_member_selector.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_selector/crew_member_selector.gd
@@ -25,6 +25,7 @@ func _on_character_selected(selected_character: Character, button_end_state: boo
 func disable_all() -> void:
     for crew_selector in crew_selector_buttons:
         crew_selector.disable()
+        crew_selector.button.button_pressed = false
 
 func enable_all() -> void:
     for crew_selector in crew_selector_buttons:

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_selector/crew_selector_button.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_selector/crew_selector_button.gd
@@ -20,3 +20,9 @@ func set_character(new_character: Character) -> void:
 
 func _on_button_pressed() -> void:
     character_selected.emit(character, button.button_pressed)
+
+func disable() -> void:
+    button.disabled = true
+
+func enable() -> void:
+    button.disabled = false

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/reroll_button.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/reroll_button.gd
@@ -4,6 +4,7 @@ signal hovered_available_reroll
 signal exited_available_reroll
 
 @export var reroll_cooldown: float = 1.5
+var cooldown_tween: Tween
 
 func _ready() -> void:
     mouse_entered.connect(_on_mouse_entered)
@@ -11,6 +12,8 @@ func _ready() -> void:
     pressed.connect(_on_pressed)
 
 func _set_disabled(new_value: bool):
+    if cooldown_tween != null and cooldown_tween.is_running():
+        cooldown_tween.kill()
     disabled = new_value
     _on_disabled_changed()
 
@@ -30,7 +33,7 @@ func _on_disabled_changed():
 
 func _on_pressed():
     _set_disabled(true)
-    var cooldown_tween = create_tween()
+    cooldown_tween = create_tween()
     cooldown_tween.tween_callback(_on_cooldown_complete).set_delay(reroll_cooldown)
 
 func _on_cooldown_complete():

--- a/game/src/gameplay/gameplay.gd
+++ b/game/src/gameplay/gameplay.gd
@@ -14,10 +14,14 @@ func _ready() -> void:
     go_inside_button.pressed.connect(go_inside)
     go_outside_button.pressed.connect(go_outside)
 
+    outdoor_root.charge_warmup.connect(charge_zoom_in)
+    outdoor_root.charge_cooldown.connect(charge_zoom_out)
+
 func go_inside() -> void:
     # we can do fancier stuff, like take a callback to only do once the screen's 
     # hidden from the calling state. We'll just make assumptions for now, since we only
     # have two states to manage.
+    outdoor_root.transition_out()
 
     # prepare logical actions that need to happen on the transition in
     var transition_while_hidden = func():
@@ -56,3 +60,15 @@ func go_outside() -> void:
     zoom_out_tween.set_trans(Tween.TRANS_CUBIC)
     zoom_out_tween.tween_property(indoor_canvas, "scale", Vector2.ONE * .9, .5)
     zoom_out_tween.tween_property(indoor_canvas, "scale", Vector2.ONE, .25)
+
+func charge_zoom_in(duration):
+    var zoom_in_tween = create_tween()
+    zoom_in_tween.set_ease(Tween.EASE_OUT)
+    zoom_in_tween.set_trans(Tween.TRANS_CUBIC)
+    zoom_in_tween.tween_property(outdoor_canvas, "scale", Vector2.ONE * 1.1, duration)
+
+func charge_zoom_out(duration):
+    var zoom_in_tween = create_tween()
+    zoom_in_tween.set_ease(Tween.EASE_OUT)
+    zoom_in_tween.set_trans(Tween.TRANS_CUBIC)
+    zoom_in_tween.tween_property(outdoor_canvas, "scale", Vector2.ONE, duration)

--- a/game/src/shared_ui/character_action_display/character_action_display.gd
+++ b/game/src/shared_ui/character_action_display/character_action_display.gd
@@ -46,7 +46,7 @@ func toggle_freeze() -> void:
     )
 
 func _handle_freeze_roll_action(event: InputEvent):
-    if event.is_action_pressed("freeze_roll"):
+    if event.is_action_pressed("freeze_roll") and not button.disabled:
         toggle_freeze()
         get_viewport().set_input_as_handled()
 
@@ -81,3 +81,9 @@ func _cycle_die_result_display(rand_value: float) -> void:
 
 func set_rolling_display(new_rolling_display: bool):
     rolling_display = new_rolling_display
+
+func disable() -> void:
+    button.disabled = true
+
+func enable() -> void:
+    button.disabled = false


### PR DESCRIPTION
Disables buttons and hides hud as combat begins, then returns it to its original state afterward.

Resource values still update right when the button is pressed right now - that'll be dealt with in a separate PR.