### PR TITLE
SFX - Hook Up Non-Icon Buttons

### DIFF
--- a/game/src/audio_manager/audio_manager.gd
+++ b/game/src/audio_manager/audio_manager.gd
@@ -37,10 +37,28 @@ func _start_background_music():
 
 #region Button mouse entered
 
+func _on_character_info_panel_close_button_mouse_entered():
+    SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
+
+func _on_charge_button_mouse_entered():
+    SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
+
+func _on_close_screen_notification_button_mouse_entered():
+    SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
+
 func _on_exit_button_mouse_entered():
     SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
 
+func _on_go_inside_button_mouse_entered():
+    SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
+
+func _on_lock_button_mouse_entered():
+    SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
+
 func _on_quit_button_mouse_entered():
+    SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
+
+func _on_reroll_button_mouse_entered():
     SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
 
 func _on_reset_to_defaults_button_mouse_entered():
@@ -57,10 +75,28 @@ func _on_start_button_mouse_entered():
 
 #region Button press
 
+func _on_character_info_panel_close_button_pressed():
+    SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
+
+func _on_charge_button_pressed():
+    SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
+
+func _on_close_screen_notification_button_pressed():
+    SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
+
 func _on_exit_button_pressed():
     SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
 
+func _on_go_inside_button_pressed():
+    SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
+
+func _on_lock_button_pressed():
+    SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
+
 func _on_quit_button_pressed():
+    SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
+
+func _on_reroll_button_pressed():
     SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
 
 func _on_settings_button_pressed():

--- a/game/src/audio_manager/audio_manager.gd
+++ b/game/src/audio_manager/audio_manager.gd
@@ -27,6 +27,11 @@ func on_sfx_volume_updated():
     SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
 
 
+# Listen for a custom signal in order to ignore hovering over disabled buttons.
+func on_enabled_button_mouse_entered():
+    SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
+
+
 # After leaving the start menu, start playing the background music.
 func _start_background_music():
     if SoundManager.is_music_playing():
@@ -37,6 +42,9 @@ func _start_background_music():
 
 #region Button mouse entered
 
+func _on_browse_new_hires_button_mouse_entered():
+    SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
+
 func _on_character_info_panel_close_button_mouse_entered():
     SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
 
@@ -46,13 +54,31 @@ func _on_charge_button_mouse_entered():
 func _on_close_screen_notification_button_mouse_entered():
     SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
 
+func _on_crew_member_detail_exit_button_mouse_entered():
+    SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
+
 func _on_exit_button_mouse_entered():
     SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
 
 func _on_go_inside_button_mouse_entered():
     SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
 
+func _on_go_outside_button_mouse_entered():
+    SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
+
+func _on_hire_detail_exit_button_mouse_entered():
+    SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
+
+func _on_hire_preview_display_cancel_button_mouse_entered():
+    SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
+
 func _on_lock_button_mouse_entered():
+    SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
+
+func _on_new_hire_preview_button_mouse_entered():
+    SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
+
+func _on_purchase_button_mouse_entered():
     SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
 
 func _on_quit_button_mouse_entered():
@@ -75,6 +101,9 @@ func _on_start_button_mouse_entered():
 
 #region Button press
 
+func _on_browse_new_hires_button_pressed():
+    SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
+
 func _on_character_info_panel_close_button_pressed():
     SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
 
@@ -84,13 +113,32 @@ func _on_charge_button_pressed():
 func _on_close_screen_notification_button_pressed():
     SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
 
+func _on_crew_member_detail_exit_button_pressed():
+    SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
+
 func _on_exit_button_pressed():
     SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
 
 func _on_go_inside_button_pressed():
     SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
 
+func _on_go_outside_button_pressed():
+    SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
+
+func _on_hire_detail_exit_button_pressed():
+    SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
+
+func _on_hire_preview_display_cancel_button_pressed():
+    SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
+
 func _on_lock_button_pressed():
+    SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
+
+func _on_new_hire_preview_button_pressed():
+    SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
+
+# Reused for 2 buttons.
+func _on_purchase_button_pressed():
     SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
 
 func _on_quit_button_pressed():

--- a/game/src/audio_manager/audio_manager.gd
+++ b/game/src/audio_manager/audio_manager.gd
@@ -37,6 +37,9 @@ func _start_background_music():
 
 #region Button mouse entered
 
+func _on_exit_button_mouse_entered():
+    SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
+
 func _on_quit_button_mouse_entered():
     SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
 
@@ -53,6 +56,9 @@ func _on_start_button_mouse_entered():
 
 
 #region Button press
+
+func _on_exit_button_pressed():
+    SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
 
 func _on_quit_button_pressed():
     SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)

--- a/game/src/back_to_start_menu_button/BackToStartMenuButton.tscn
+++ b/game/src/back_to_start_menu_button/BackToStartMenuButton.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://mq5u7di7yh8m"]
+[gd_scene load_steps=4 format=3 uid="uid://mq5u7di7yh8m"]
 
 [ext_resource type="Script" path="res://src/back_to_start_menu_button/back_to_start_menu_button.gd" id="1_c71e6"]
 [ext_resource type="Theme" uid="uid://dk5iv042psfw" path="res://assets/themes/Default.tres" id="1_oosi7"]
+[ext_resource type="PackedScene" uid="uid://h1fowbxngb70" path="res://src/audio_manager/AudioManager.tscn" id="3_3mvrq"]
 
 [node name="BackToStartMenuButton" type="Control"]
 layout_direction = 3
@@ -10,10 +11,14 @@ anchors_preset = 0
 theme = ExtResource("1_oosi7")
 script = ExtResource("1_c71e6")
 
+[node name="AudioManager" parent="." instance=ExtResource("3_3mvrq")]
+
 [node name="ExitButton" type="Button" parent="."]
 layout_mode = 0
 offset_right = 8.0
 offset_bottom = 8.0
 text = "X"
 
+[connection signal="mouse_entered" from="ExitButton" to="AudioManager" method="_on_exit_button_mouse_entered"]
 [connection signal="pressed" from="ExitButton" to="." method="_on_exit_button_pressed"]
+[connection signal="pressed" from="ExitButton" to="AudioManager" method="_on_exit_button_pressed"]

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=19 format=3 uid="uid://b6k6baalu42w7"]
+[gd_scene load_steps=20 format=3 uid="uid://b6k6baalu42w7"]
 
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd" id="1_3j823"]
 [ext_resource type="PackedScene" uid="uid://da57hkojchohp" path="res://src/shared_ui/resource_display/health_display.tscn" id="2_6fssr"]
+[ext_resource type="PackedScene" uid="uid://h1fowbxngb70" path="res://src/audio_manager/AudioManager.tscn" id="2_aqfti"]
 [ext_resource type="LabelSettings" uid="uid://2bu6p3hkt8lk" path="res://assets/label_settings/ColorWarning.tres" id="2_p0vkd"]
 [ext_resource type="PackedScene" uid="uid://cnbbp4gy833n" path="res://src/shared_ui/resource_display/money_display.tscn" id="2_ualkn"]
-[ext_resource type="PackedScene" path="res://src/shared_ui/resource_display/fuel_display.tscn" id="3_n5xb3"]
+[ext_resource type="PackedScene" uid="uid://cjb6144n5q1b1" path="res://src/shared_ui/resource_display/fuel_display.tscn" id="3_n5xb3"]
 [ext_resource type="PackedScene" uid="uid://cib1fq003l5jx" path="res://src/indoor_preparation/screen_displays/shared/screen_notification.tscn" id="3_rl23t"]
 [ext_resource type="PackedScene" uid="uid://cf5qy6u2j3hhw" path="res://assets/themes/fuel_display_mini.tscn" id="5_3m24g"]
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/crew_selector/crew_member_selector.gd" id="5_vpr4d"]
@@ -16,7 +17,7 @@
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/reroll_button.gd" id="7_xg4o8"]
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/total_power_display.gd" id="9_cb4ss"]
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/barrier_preview.gd" id="9_iui7q"]
-[ext_resource type="PackedScene" uid="uid://vnu6f53bf3ur" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/character_info_panel.tscn" id="16_oou66"]
+[ext_resource type="PackedScene" uid="uid://6tyicfyiq5gf" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/character_info_panel.tscn" id="16_oou66"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_8a5xg"]
 content_margin_left = 5.0
@@ -34,6 +35,8 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_3j823")
+
+[node name="AudioManager" parent="." instance=ExtResource("2_aqfti")]
 
 [node name="TopBar" type="MarginContainer" parent="."]
 layout_mode = 0
@@ -503,5 +506,11 @@ offset_right = 0.0
 offset_bottom = 0.0
 grow_vertical = 0
 
+[connection signal="mouse_entered" from="BottomInfoDisplay/Center/TopEdge/RerollButton" to="AudioManager" method="_on_reroll_button_mouse_entered"]
 [connection signal="pressed" from="BottomInfoDisplay/Center/TopEdge/RerollButton" to="." method="_on_mock_reroll_button_pressed"]
+[connection signal="pressed" from="BottomInfoDisplay/Center/TopEdge/RerollButton" to="AudioManager" method="_on_reroll_button_pressed"]
+[connection signal="mouse_entered" from="BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay/PanelContainer/VBoxContainer/ChargeButton" to="AudioManager" method="_on_charge_button_mouse_entered"]
 [connection signal="pressed" from="BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay/PanelContainer/VBoxContainer/ChargeButton" to="." method="_on_mock_attack_button_pressed"]
+[connection signal="pressed" from="BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay/PanelContainer/VBoxContainer/ChargeButton" to="AudioManager" method="_on_charge_button_pressed"]
+[connection signal="mouse_entered" from="GoInsideButton" to="AudioManager" method="_on_go_inside_button_mouse_entered"]
+[connection signal="pressed" from="GoInsideButton" to="AudioManager" method="_on_go_inside_button_pressed"]

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/character_info_panel.tscn
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/character_info_panel.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=8 format=3 uid="uid://vnu6f53bf3ur"]
+[gd_scene load_steps=9 format=3 uid="uid://6tyicfyiq5gf"]
 
 [ext_resource type="Theme" uid="uid://dk5iv042psfw" path="res://assets/themes/Default.tres" id="1_e7u35"]
 [ext_resource type="Texture2D" uid="uid://bic3i142epdt3" path="res://assets/art/placeholder_threat.png" id="1_jchug"]
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/character_info_panel.gd" id="2_b64bf"]
 [ext_resource type="PackedScene" uid="uid://lw7wcqkoqifj" path="res://src/shared_ui/die_result/DieResult.tscn" id="3_hsll6"]
+[ext_resource type="PackedScene" uid="uid://h1fowbxngb70" path="res://src/audio_manager/AudioManager.tscn" id="3_ygbom"]
 [ext_resource type="Texture2D" uid="uid://c8dsnvyqbn3fh" path="res://assets/art/lock_icon.png" id="5_8swb4"]
 [ext_resource type="Texture2D" uid="uid://r7a1wa1ifq57" path="res://assets/art/placeholder_close_button.png" id="6_5bbwo"]
 
@@ -30,6 +31,8 @@ grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_e7u35")
 script = ExtResource("2_b64bf")
+
+[node name="AudioManager" parent="." instance=ExtResource("3_ygbom")]
 
 [node name="MC" type="MarginContainer" parent="."]
 layout_mode = 2
@@ -167,3 +170,8 @@ layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 0
 icon = ExtResource("6_5bbwo")
+
+[connection signal="mouse_entered" from="MC/VB/Current/LockButton" to="AudioManager" method="_on_lock_button_mouse_entered"]
+[connection signal="pressed" from="MC/VB/Current/LockButton" to="AudioManager" method="_on_lock_button_pressed"]
+[connection signal="mouse_entered" from="CloseButton" to="AudioManager" method="_on_character_info_panel_close_button_mouse_entered"]
+[connection signal="pressed" from="CloseButton" to="AudioManager" method="_on_character_info_panel_close_button_pressed"]

--- a/game/src/indoor_preparation/indoor_preparation.tscn
+++ b/game/src/indoor_preparation/indoor_preparation.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=27 format=3 uid="uid://b73yb04wjxq8"]
+[gd_scene load_steps=28 format=3 uid="uid://b73yb04wjxq8"]
 
 [ext_resource type="Texture2D" uid="uid://l3l2yqfmprg5" path="res://assets/art/ld_56_indoors.jpg" id="1_f348j"]
 [ext_resource type="Script" path="res://src/indoor_preparation/indoor_preparation.gd" id="2_0rynj"]
 [ext_resource type="Theme" uid="uid://dk5iv042psfw" path="res://assets/themes/Default.tres" id="2_bky62"]
+[ext_resource type="PackedScene" uid="uid://h1fowbxngb70" path="res://src/audio_manager/AudioManager.tscn" id="3_3bed5"]
 [ext_resource type="Script" path="res://src/indoor_preparation/screen.gd" id="3_culvi"]
 [ext_resource type="PackedScene" uid="uid://7vx27hr83tx0" path="res://src/indoor_preparation/screen_displays/home_display.tscn" id="3_eot0a"]
 [ext_resource type="PackedScene" uid="uid://dw8jtxw6u5x40" path="res://src/indoor_preparation/screen_displays/browse_hires/browse_hires.tscn" id="4_note4"]
@@ -25,7 +26,7 @@
 [ext_resource type="Resource" uid="uid://1nhgxq12mwuo" path="res://assets/data/characters/011_test_pal.tres" id="20_pbwmt"]
 [ext_resource type="Resource" uid="uid://beppcdvy1b3s0" path="res://assets/data/characters/012_test_pal.tres" id="21_71v0u"]
 [ext_resource type="PackedScene" uid="uid://cnbbp4gy833n" path="res://src/shared_ui/resource_display/money_display.tscn" id="25_dg1g1"]
-[ext_resource type="PackedScene" path="res://src/shared_ui/resource_display/fuel_display.tscn" id="26_fgbkb"]
+[ext_resource type="PackedScene" uid="uid://cjb6144n5q1b1" path="res://src/shared_ui/resource_display/fuel_display.tscn" id="26_fgbkb"]
 
 [node name="IndoorPreparation" type="Control"]
 layout_mode = 3
@@ -36,6 +37,8 @@ grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("2_bky62")
 script = ExtResource("2_0rynj")
+
+[node name="AudioManager" parent="." instance=ExtResource("3_3bed5")]
 
 [node name="TextureRect" type="TextureRect" parent="."]
 layout_mode = 0
@@ -298,3 +301,6 @@ layout_mode = 2
 
 [node name="FuelDisplay" parent="VBoxContainer" instance=ExtResource("26_fgbkb")]
 layout_mode = 2
+
+[connection signal="mouse_entered" from="GoOutsideButton" to="AudioManager" method="_on_go_outside_button_mouse_entered"]
+[connection signal="pressed" from="GoOutsideButton" to="AudioManager" method="_on_go_outside_button_pressed"]

--- a/game/src/indoor_preparation/screen_displays/browse_hires/browse_hires.tscn
+++ b/game/src/indoor_preparation/screen_displays/browse_hires/browse_hires.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=5 format=3 uid="uid://dw8jtxw6u5x40"]
+[gd_scene load_steps=6 format=3 uid="uid://dw8jtxw6u5x40"]
 
 [ext_resource type="Theme" uid="uid://dmwrgmv8lathf" path="res://assets/themes/ScreenTheme.tres" id="1_rti5y"]
 [ext_resource type="PackedScene" uid="uid://emsj3qtryn1x" path="res://src/indoor_preparation/screen_displays/browse_hires/new_hire_preview.tscn" id="2_b5o7f"]
 [ext_resource type="Script" path="res://src/indoor_preparation/screen_displays/browse_hires/browse_hires.gd" id="2_jeptc"]
 [ext_resource type="Texture2D" uid="uid://r7a1wa1ifq57" path="res://assets/art/placeholder_close_button.png" id="3_ojo6x"]
+[ext_resource type="PackedScene" uid="uid://h1fowbxngb70" path="res://src/audio_manager/AudioManager.tscn" id="3_ominw"]
 
 [node name="HirePreviewDisplay" type="Control"]
 layout_mode = 3
@@ -14,6 +15,8 @@ grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_rti5y")
 script = ExtResource("2_jeptc")
+
+[node name="AudioManager" parent="." instance=ExtResource("3_ominw")]
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -58,3 +61,6 @@ offset_left = -32.0
 offset_bottom = 32.0
 grow_horizontal = 0
 icon = ExtResource("3_ojo6x")
+
+[connection signal="mouse_entered" from="CancelButton" to="AudioManager" method="_on_hire_preview_display_cancel_button_mouse_entered"]
+[connection signal="pressed" from="CancelButton" to="AudioManager" method="_on_hire_preview_display_cancel_button_pressed"]

--- a/game/src/indoor_preparation/screen_displays/browse_hires/new_hire_preview.tscn
+++ b/game/src/indoor_preparation/screen_displays/browse_hires/new_hire_preview.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=5 format=3 uid="uid://emsj3qtryn1x"]
+[gd_scene load_steps=6 format=3 uid="uid://emsj3qtryn1x"]
 
 [ext_resource type="Texture2D" uid="uid://dsi835iplnoul" path="res://assets/art/placeholder_ally.png" id="1_sufm1"]
 [ext_resource type="Script" path="res://src/indoor_preparation/screen_displays/browse_hires/new_hire_preview.gd" id="1_yy8kg"]
+[ext_resource type="PackedScene" uid="uid://h1fowbxngb70" path="res://src/audio_manager/AudioManager.tscn" id="2_fnu7a"]
 [ext_resource type="PackedScene" uid="uid://lw7wcqkoqifj" path="res://src/shared_ui/die_result/DieResult.tscn" id="3_jlg8d"]
 [ext_resource type="Theme" uid="uid://dmwrgmv8lathf" path="res://assets/themes/ScreenTheme.tres" id="4_yjvkr"]
 
@@ -14,6 +15,8 @@ grow_horizontal = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 script = ExtResource("1_yy8kg")
+
+[node name="AudioManager" parent="." instance=ExtResource("2_fnu7a")]
 
 [node name="Button" type="Button" parent="."]
 layout_mode = 2
@@ -132,3 +135,6 @@ theme = ExtResource("4_yjvkr")
 [node name="DieResult6" parent="MarginContainer/VBoxContainer/HBoxContainer/PanelContainer/MarginContainer/VBoxContainer/ActionsPreview2" instance=ExtResource("3_jlg8d")]
 layout_mode = 2
 theme = ExtResource("4_yjvkr")
+
+[connection signal="mouse_entered" from="Button" to="AudioManager" method="_on_new_hire_preview_button_mouse_entered"]
+[connection signal="pressed" from="Button" to="AudioManager" method="_on_new_hire_preview_button_pressed"]

--- a/game/src/indoor_preparation/screen_displays/crew_member_detail/crew_member_detail.tscn
+++ b/game/src/indoor_preparation/screen_displays/crew_member_detail/crew_member_detail.tscn
@@ -1,14 +1,20 @@
-[gd_scene load_steps=4 format=3 uid="uid://bvpdxuf4a56pf"]
+[gd_scene load_steps=5 format=3 uid="uid://bvpdxuf4a56pf"]
 
 [ext_resource type="PackedScene" uid="uid://d0wnwi5rcyku" path="res://src/indoor_preparation/screen_displays/shared/character_detail/character_detail.tscn" id="1_i2m3f"]
 [ext_resource type="Script" path="res://src/indoor_preparation/screen_displays/crew_member_detail/crew_member_detail.gd" id="2_47e65"]
 [ext_resource type="PackedScene" uid="uid://b4xnwcpb30o20" path="res://src/indoor_preparation/screen_displays/crew_member_detail/upgrade_prompt.tscn" id="2_wa450"]
+[ext_resource type="PackedScene" uid="uid://h1fowbxngb70" path="res://src/audio_manager/AudioManager.tscn" id="3_tjpp0"]
 
 [node name="CrewMemberDetail" instance=ExtResource("1_i2m3f")]
 script = ExtResource("2_47e65")
 
+[node name="AudioManager" parent="." index="0" instance=ExtResource("3_tjpp0")]
+
 [node name="UpgradePrompt" parent="IconAndCost" index="1" instance=ExtResource("2_wa450")]
 layout_mode = 2
 
-[node name="OptionalHeader" parent="." index="5"]
+[node name="OptionalHeader" parent="." index="6"]
 visible = false
+
+[connection signal="mouse_entered" from="ExitButton" to="AudioManager" method="_on_crew_member_detail_exit_button_mouse_entered"]
+[connection signal="pressed" from="ExitButton" to="AudioManager" method="_on_crew_member_detail_exit_button_pressed"]

--- a/game/src/indoor_preparation/screen_displays/crew_member_detail/upgrade_prompt.tscn
+++ b/game/src/indoor_preparation/screen_displays/crew_member_detail/upgrade_prompt.tscn
@@ -1,10 +1,13 @@
-[gd_scene load_steps=2 format=3 uid="uid://b4xnwcpb30o20"]
+[gd_scene load_steps=3 format=3 uid="uid://b4xnwcpb30o20"]
 
 [ext_resource type="Script" path="res://src/indoor_preparation/screen_displays/shared/upgrades/upgrade_cost_prompt.gd" id="1_r5pou"]
+[ext_resource type="PackedScene" uid="uid://h1fowbxngb70" path="res://src/audio_manager/AudioManager.tscn" id="2_o2aex"]
 
 [node name="UpgradePrompt" type="PanelContainer"]
 custom_minimum_size = Vector2(95, 0)
 script = ExtResource("1_r5pou")
+
+[node name="AudioManager" parent="." instance=ExtResource("2_o2aex")]
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2
@@ -32,3 +35,6 @@ layout_mode = 2
 theme_override_font_sizes/font_size = 32
 disabled = true
 text = "BUY"
+
+[connection signal="mouse_entered" from="MarginContainer/VBoxContainer/PurchaseButton" to="." method="_on_purchase_button_mouse_entered"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/PurchaseButton" to="AudioManager" method="_on_purchase_button_pressed"]

--- a/game/src/indoor_preparation/screen_displays/hire_detail/hire_detail.tscn
+++ b/game/src/indoor_preparation/screen_displays/hire_detail/hire_detail.tscn
@@ -1,11 +1,17 @@
-[gd_scene load_steps=4 format=3 uid="uid://cdb8nv77bouh1"]
+[gd_scene load_steps=5 format=3 uid="uid://cdb8nv77bouh1"]
 
 [ext_resource type="PackedScene" uid="uid://d0wnwi5rcyku" path="res://src/indoor_preparation/screen_displays/shared/character_detail/character_detail.tscn" id="1_mlfm0"]
 [ext_resource type="PackedScene" uid="uid://byvjel7rc8ms0" path="res://src/indoor_preparation/screen_displays/hire_detail/hire_prompt.tscn" id="2_36qio"]
 [ext_resource type="Script" path="res://src/indoor_preparation/screen_displays/hire_detail/hire_detail.gd" id="2_dyr55"]
+[ext_resource type="PackedScene" uid="uid://h1fowbxngb70" path="res://src/audio_manager/AudioManager.tscn" id="3_15ipv"]
 
 [node name="HireDetail" instance=ExtResource("1_mlfm0")]
 script = ExtResource("2_dyr55")
 
+[node name="AudioManager" parent="." index="0" instance=ExtResource("3_15ipv")]
+
 [node name="HirePrompt" parent="IconAndCost" index="1" instance=ExtResource("2_36qio")]
 layout_mode = 2
+
+[connection signal="mouse_entered" from="ExitButton" to="AudioManager" method="_on_hire_detail_exit_button_mouse_entered"]
+[connection signal="pressed" from="ExitButton" to="AudioManager" method="_on_hire_detail_exit_button_pressed"]

--- a/game/src/indoor_preparation/screen_displays/hire_detail/hire_prompt.tscn
+++ b/game/src/indoor_preparation/screen_displays/hire_detail/hire_prompt.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=2 format=3 uid="uid://byvjel7rc8ms0"]
+[gd_scene load_steps=3 format=3 uid="uid://byvjel7rc8ms0"]
 
 [ext_resource type="Script" path="res://src/indoor_preparation/screen_displays/hire_detail/hire_prompt.gd" id="1_8agtl"]
+[ext_resource type="PackedScene" uid="uid://h1fowbxngb70" path="res://src/audio_manager/AudioManager.tscn" id="2_v3u4e"]
 
 [node name="HirePrompt" type="PanelContainer"]
 script = ExtResource("1_8agtl")
+
+[node name="AudioManager" parent="." instance=ExtResource("2_v3u4e")]
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2
@@ -28,3 +31,6 @@ autowrap_mode = 2
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
 text = "HIRE"
+
+[connection signal="mouse_entered" from="MarginContainer/VBoxContainer/PurchaseButton" to="AudioManager" method="_on_purchase_button_mouse_entered"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/PurchaseButton" to="AudioManager" method="_on_purchase_button_pressed"]

--- a/game/src/indoor_preparation/screen_displays/home_display.tscn
+++ b/game/src/indoor_preparation/screen_displays/home_display.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=5 format=3 uid="uid://7vx27hr83tx0"]
+[gd_scene load_steps=6 format=3 uid="uid://7vx27hr83tx0"]
 
 [ext_resource type="Script" path="res://src/indoor_preparation/screen_displays/home_display.gd" id="1_b3nrn"]
 [ext_resource type="Theme" uid="uid://dmwrgmv8lathf" path="res://assets/themes/ScreenTheme.tres" id="1_d2gyf"]
+[ext_resource type="PackedScene" uid="uid://h1fowbxngb70" path="res://src/audio_manager/AudioManager.tscn" id="3_2jj1q"]
 [ext_resource type="Texture2D" uid="uid://bic3i142epdt3" path="res://assets/art/placeholder_threat.png" id="3_4hdf6"]
 [ext_resource type="Texture2D" uid="uid://cmdqbv4iraqg6" path="res://assets/art/MAGIC_icon_64x64.png" id="4_o5aea"]
 
@@ -14,6 +15,8 @@ grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_d2gyf")
 script = ExtResource("1_b3nrn")
+
+[node name="AudioManager" parent="." instance=ExtResource("3_2jj1q")]
 
 [node name="MainContents" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -128,3 +131,6 @@ theme_override_constants/margin_bottom = 10
 [node name="Button" type="Button" parent="MarginContainer"]
 layout_mode = 2
 text = "BROWSE NEW HIRES"
+
+[connection signal="mouse_entered" from="MarginContainer/Button" to="AudioManager" method="_on_browse_new_hires_button_mouse_entered"]
+[connection signal="pressed" from="MarginContainer/Button" to="AudioManager" method="_on_browse_new_hires_button_pressed"]

--- a/game/src/indoor_preparation/screen_displays/shared/screen_notification.tscn
+++ b/game/src/indoor_preparation/screen_displays/shared/screen_notification.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=3 uid="uid://cib1fq003l5jx"]
+[gd_scene load_steps=5 format=3 uid="uid://cib1fq003l5jx"]
 
 [ext_resource type="Theme" uid="uid://dq0psiuuo404u" path="res://assets/themes/Notification_Error.tres" id="1_02cx6"]
 [ext_resource type="Script" path="res://src/indoor_preparation/screen_displays/shared/screen_notification.gd" id="2_hcuqa"]
+[ext_resource type="PackedScene" uid="uid://h1fowbxngb70" path="res://src/audio_manager/AudioManager.tscn" id="3_lrapv"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_2lwms"]
 bg_color = Color(1, 1, 1, 1)
@@ -17,6 +18,8 @@ grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_02cx6")
 script = ExtResource("2_hcuqa")
+
+[node name="AudioManager" parent="." instance=ExtResource("3_lrapv")]
 
 [node name="PC" type="PanelContainer" parent="."]
 layout_mode = 1
@@ -85,3 +88,6 @@ show_percentage = false
 
 [node name="ExpirationTimer" type="Timer" parent="."]
 one_shot = true
+
+[connection signal="mouse_entered" from="PC/MC/VBC/PC2/MC2/VBC2/Button" to="AudioManager" method="_on_close_screen_notification_button_mouse_entered"]
+[connection signal="pressed" from="PC/MC/VBC/PC2/MC2/VBC2/Button" to="AudioManager" method="_on_close_screen_notification_button_pressed"]

--- a/game/src/indoor_preparation/screen_displays/shared/upgrades/upgrade_cost_prompt.gd
+++ b/game/src/indoor_preparation/screen_displays/shared/upgrades/upgrade_cost_prompt.gd
@@ -2,6 +2,7 @@ class_name UpgradeCostPrompt extends Node
 
 signal upgrade_purchase_pressed(upgrade_choice: UpgradeChoice)
 
+@onready var audio_manager: AudioManager = $AudioManager
 @onready var cost_display: RichTextLabel = $MarginContainer/VBoxContainer/CostDisplay
 @onready var purchase_button: Button = $MarginContainer/VBoxContainer/PurchaseButton
 
@@ -68,6 +69,13 @@ func clear_upgrade_data():
     selected_upgrade_purchased = false
     previewed_upgrade = null
     update_display_elements(false, false)
+
+func _on_purchase_button_mouse_entered():
+    # Guardian check to only play a hover sound effect for an enabled button.
+    if purchase_button.disabled:
+        return
+
+    audio_manager.on_enabled_button_mouse_entered()
 
 func _on_purchase_button_pressed():
     upgrade_purchase_pressed.emit(selected_upgrade)


### PR DESCRIPTION
Hook up click and hover sound effects to all non-icon buttons.

## Implementation Details

Add an instance of `AudioManager` to every scene that needs to play a sound effect, to reduce the amount of chaining abstraction between signals and audio setup.

Add hover and click sound effects to the `X` button in the top-right corner of screens.

For the one disabled button in the gameplay indoors, check if the button is enabled before playing a hover sound effect.

### Out of Scope

Character heads and upgrade circular icons do not have sound effects yet. We may want character inputs to have the option of custom audio based on which character it is.