### PR TITLE
Combat results communication

### DIFF
--- a/game/src/battlefield_outdoors/BattlefieldOutdoors.tscn
+++ b/game/src/battlefield_outdoors/BattlefieldOutdoors.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=6 format=3 uid="uid://c5dvnfrvyjol6"]
+[gd_scene load_steps=7 format=3 uid="uid://c5dvnfrvyjol6"]
 
 [ext_resource type="Theme" uid="uid://dk5iv042psfw" path="res://assets/themes/Default.tres" id="1_cei1v"]
 [ext_resource type="PackedScene" uid="uid://b6k6baalu42w7" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn" id="1_wxoya"]
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors.gd" id="2_ni2i7"]
 [ext_resource type="PackedScene" uid="uid://ceesyhnktnbd1" path="res://src/battlefield_outdoors/battlefield_outdoors_barrier/BattlefieldOutdoorsBarrier.tscn" id="2_p4mcn"]
 [ext_resource type="PackedScene" uid="uid://bwpa5wbo5ct7g" path="res://src/battlefield_outdoors/battlefield_outdoors_war_transport/BattlefieldOutdoorsWarTransport.tscn" id="3_etui0"]
+[ext_resource type="PackedScene" uid="uid://cnphrbnb2wrnf" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/combat_results_summary.tscn" id="6_3fojy"]
 
 [node name="BattlefieldOutdoors" type="Control"]
 layout_mode = 3
@@ -43,3 +44,10 @@ anchor_right = 0.5
 anchor_bottom = 0.4
 
 [node name="BattlefieldOutdoorsWarTransport" parent="AnchorOfWarTransport" instance=ExtResource("3_etui0")]
+
+[node name="CombatResultsSummary" parent="." instance=ExtResource("6_3fojy")]
+visible = false
+layout_mode = 1
+anchors_preset = -1
+anchor_top = 0.3
+anchor_bottom = 0.3

--- a/game/src/battlefield_outdoors/BattlefieldOutdoors.tscn
+++ b/game/src/battlefield_outdoors/BattlefieldOutdoors.tscn
@@ -1,11 +1,10 @@
-[gd_scene load_steps=7 format=3 uid="uid://c5dvnfrvyjol6"]
+[gd_scene load_steps=6 format=3 uid="uid://c5dvnfrvyjol6"]
 
 [ext_resource type="Theme" uid="uid://dk5iv042psfw" path="res://assets/themes/Default.tres" id="1_cei1v"]
 [ext_resource type="PackedScene" uid="uid://b6k6baalu42w7" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn" id="1_wxoya"]
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors.gd" id="2_ni2i7"]
 [ext_resource type="PackedScene" uid="uid://ceesyhnktnbd1" path="res://src/battlefield_outdoors/battlefield_outdoors_barrier/BattlefieldOutdoorsBarrier.tscn" id="2_p4mcn"]
 [ext_resource type="PackedScene" uid="uid://bwpa5wbo5ct7g" path="res://src/battlefield_outdoors/battlefield_outdoors_war_transport/BattlefieldOutdoorsWarTransport.tscn" id="3_etui0"]
-[ext_resource type="PackedScene" uid="uid://cnphrbnb2wrnf" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/combat_results_summary.tscn" id="6_3fojy"]
 
 [node name="BattlefieldOutdoors" type="Control"]
 layout_mode = 3
@@ -44,10 +43,3 @@ anchor_right = 0.5
 anchor_bottom = 0.4
 
 [node name="BattlefieldOutdoorsWarTransport" parent="AnchorOfWarTransport" instance=ExtResource("3_etui0")]
-
-[node name="CombatResultsSummary" parent="." instance=ExtResource("6_3fojy")]
-visible = false
-layout_mode = 1
-anchors_preset = -1
-anchor_top = 0.3
-anchor_bottom = 0.3

--- a/game/src/battlefield_outdoors/battlefield_outdoors.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors.gd
@@ -16,6 +16,7 @@ signal insufficient_fuel()
 
 var combat_math_formulas: CombatMathFormulas = CombatMathFormulas.new()
 var charge_sequence_tween: Tween
+var combat_result: CombatResultsSummary.CombatResult = CombatResultsSummary.CombatResult.new()
 
 func _ready() -> void:
     insufficient_fuel.connect(battlefield_outdoors_hud._on_insufficient_fuel)
@@ -76,9 +77,11 @@ func _apply_combat_damage() -> void:
         Database.current_barrier_stat_type_to_overcome,
         Database.current_matching_stat_type_multiplier
     )
-    var damage_amount = (
-        Database.current_barrier_cost_to_overcome_number - player_strength
+    var damage_amount = max(
+        Database.current_barrier_cost_to_overcome_number - player_strength,
+        0
     )
+    combat_result.health_change = -damage_amount
 
     if damage_amount > 0:
         updated_health -= damage_amount
@@ -115,6 +118,8 @@ func _generate_barrier_data() -> BarrierData:
 func _apply_combat_rewards() -> void:
     var money_change = randi_range(1, 100)
     var fuel_change = randi_range(1, 3)
+    combat_result.money_change = money_change
+    combat_result.fuel_change = fuel_change
 
     Database.set_money(Database.current_money + money_change)
     Database.set_fuel(Database.current_fuel + fuel_change)
@@ -123,7 +128,7 @@ func _apply_combat_rewards() -> void:
         + 1
     )
 
-    combat_results_summary.set_combat_results(0, money_change, fuel_change)
+    combat_results_summary.set_combat_results_bundled(combat_result)
 
 func _on_health_empty() -> void:
     print_debug('Game over, health has reached ', Database.war_transport_health_current)

--- a/game/src/battlefield_outdoors/battlefield_outdoors.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors.gd
@@ -12,7 +12,6 @@ signal insufficient_fuel()
 
 @onready var war_transport: BattlefieldOutdoorsWarTransport = $AnchorOfWarTransport/BattlefieldOutdoorsWarTransport
 @onready var battlefield_outdoors_hud: BattlefieldOutdoorsHud = $BattlefieldOutdoorsHud
-@onready var combat_results_summary: CombatResultsSummary = $CombatResultsSummary
 
 var combat_math_formulas: CombatMathFormulas = CombatMathFormulas.new()
 var charge_sequence_tween: Tween
@@ -95,7 +94,7 @@ func _apply_combat_damage() -> void:
 func _on_charge_cooldown(_duration: float) -> void:
     _generate_and_scale_next_barrier()
     _apply_combat_rewards()
-    combat_results_summary.display_combat_results()
+    battlefield_outdoors_hud.set_combat_results(combat_result)
 
 func _generate_and_scale_next_barrier() -> void:
     var new_barrier: BarrierData = _generate_barrier_data()
@@ -127,8 +126,6 @@ func _apply_combat_rewards() -> void:
         Database.barriers_overcome_count
         + 1
     )
-
-    combat_results_summary.set_combat_results_bundled(combat_result)
 
 func _on_health_empty() -> void:
     print_debug('Game over, health has reached ', Database.war_transport_health_current)

--- a/game/src/battlefield_outdoors/battlefield_outdoors.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors.gd
@@ -12,6 +12,7 @@ signal insufficient_fuel()
 
 @onready var war_transport: BattlefieldOutdoorsWarTransport = $AnchorOfWarTransport/BattlefieldOutdoorsWarTransport
 @onready var battlefield_outdoors_hud: BattlefieldOutdoorsHud = $BattlefieldOutdoorsHud
+@onready var combat_results_summary: CombatResultsSummary = $CombatResultsSummary
 
 var combat_math_formulas: CombatMathFormulas = CombatMathFormulas.new()
 var charge_sequence_tween: Tween
@@ -91,6 +92,7 @@ func _apply_combat_damage() -> void:
 func _on_charge_cooldown(_duration: float) -> void:
     _generate_and_scale_next_barrier()
     _apply_combat_rewards()
+    combat_results_summary.display_combat_results()
 
 func _generate_and_scale_next_barrier() -> void:
     var new_barrier: BarrierData = _generate_barrier_data()
@@ -111,12 +113,17 @@ func _generate_barrier_data() -> BarrierData:
         cost_to_overcome)
 
 func _apply_combat_rewards() -> void:
-    Database.set_money(Database.current_money + randi_range(1, 100))
-    Database.set_fuel(Database.current_fuel + randi_range(1, 3))
+    var money_change = randi_range(1, 100)
+    var fuel_change = randi_range(1, 3)
+
+    Database.set_money(Database.current_money + money_change)
+    Database.set_fuel(Database.current_fuel + fuel_change)
     Database.set_barriers_overcome_count(
         Database.barriers_overcome_count
         + 1
     )
+
+    combat_results_summary.set_combat_results(0, money_change, fuel_change)
 
 func _on_health_empty() -> void:
     print_debug('Game over, health has reached ', Database.war_transport_health_current)

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn
@@ -510,6 +510,7 @@ layout_mode = 1
 anchors_preset = -1
 anchor_top = 0.4
 anchor_bottom = 0.4
+grow_vertical = 0
 
 [connection signal="pressed" from="BottomInfoDisplay/Center/TopEdge/RerollButton" to="." method="_on_mock_reroll_button_pressed"]
 [connection signal="pressed" from="BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay/PanelContainer/VBoxContainer/ChargeButton" to="." method="_on_mock_attack_button_pressed"]

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=19 format=3 uid="uid://b6k6baalu42w7"]
+[gd_scene load_steps=20 format=3 uid="uid://b6k6baalu42w7"]
 
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd" id="1_3j823"]
 [ext_resource type="PackedScene" uid="uid://da57hkojchohp" path="res://src/shared_ui/resource_display/health_display.tscn" id="2_6fssr"]
@@ -17,6 +17,7 @@
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/total_power_display.gd" id="9_cb4ss"]
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/barrier_preview.gd" id="9_iui7q"]
 [ext_resource type="PackedScene" uid="uid://vnu6f53bf3ur" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/character_info_panel.tscn" id="16_oou66"]
+[ext_resource type="PackedScene" uid="uid://cnphrbnb2wrnf" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/combat_results_summary.tscn" id="18_lgpuc"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_8a5xg"]
 content_margin_left = 5.0
@@ -502,6 +503,13 @@ offset_top = 0.0
 offset_right = 0.0
 offset_bottom = 0.0
 grow_vertical = 0
+
+[node name="CombatResultsSummary" parent="." instance=ExtResource("18_lgpuc")]
+visible = false
+layout_mode = 1
+anchors_preset = -1
+anchor_top = 0.4
+anchor_bottom = 0.4
 
 [connection signal="pressed" from="BottomInfoDisplay/Center/TopEdge/RerollButton" to="." method="_on_mock_reroll_button_pressed"]
 [connection signal="pressed" from="BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay/PanelContainer/VBoxContainer/ChargeButton" to="." method="_on_mock_attack_button_pressed"]

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
@@ -33,6 +33,7 @@ const REROLL_FAIL_DURATION = 2
 @onready var reroll_button: RerollButton = $BottomInfoDisplay/Center/TopEdge/RerollButton
 @onready var charge_button: Button = $BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay/PanelContainer/VBoxContainer/ChargeButton
 @onready var go_inside_button: Button = $GoInsideButton
+@onready var combat_results_summary: CombatResultsSummary = $CombatResultsSummary
 
 func _ready():
     _hide_warnings()
@@ -155,6 +156,9 @@ func _enable_interaction() -> void:
     crew_actions_display.enable_all()
     crew_member_selector.enable_all()
 
+func set_combat_results(combat_results: CombatResultsSummary.CombatResult) -> void:
+    combat_results_summary.set_combat_results_bundled(combat_results)
+
 func _on_charge_start() -> void:
     print("HUD charge start")
     _disable_interaction()
@@ -173,6 +177,7 @@ func _on_charge_impact(duration: float) -> void:
 func _on_charge_cooldown(duration: float) -> void:
     print("HUD charge cooldown", duration)
     # trigger refreshes & information updates
+    combat_results_summary.display_combat_results()
     _charge_mode_fadein(duration)
 
 func _on_charge_finish() -> void:

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/combat_results_summary.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/combat_results_summary.gd
@@ -14,6 +14,11 @@ func set_combat_results(health_change: int, money_change: int, fuel_change: int)
     money_change_display.set_change_amount(money_change)
     fuel_change_display.set_change_amount(fuel_change)
 
+func set_combat_results_bundled(combat_result: CombatResult):
+    health_change_display.set_change_amount(combat_result.health_change)
+    money_change_display.set_change_amount(combat_result.money_change)
+    fuel_change_display.set_change_amount(combat_result.fuel_change)
+
 func display_combat_results():
     show()
     modulate = Color.WHITE
@@ -23,3 +28,13 @@ func display_combat_results():
     display_tween.tween_property(self, "modulate", Color.TRANSPARENT, DISPLAY_DURATION)
     display_tween.parallel().tween_property(self, "position", start_position + FLOAT_OFFSET, DISPLAY_DURATION)
     display_tween.tween_callback(hide)
+
+class CombatResult extends RefCounted:
+    var health_change: int = 0
+    var money_change: int = 0
+    var fuel_change: int = 0
+
+    func _init(_health_change = 0, _money_change = 0, _fuel_change = 0) -> void:
+        health_change = _health_change
+        money_change = _money_change
+        fuel_change = _fuel_change

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/combat_results_summary.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/combat_results_summary.gd
@@ -1,0 +1,25 @@
+class_name CombatResultsSummary extends VBoxContainer
+
+const DISPLAY_DURATION: float = 2
+const FLOAT_OFFSET: Vector2 = Vector2(0, -100)
+
+@onready var health_change_display: ResourceChangeLine = $HealthChange
+@onready var money_change_display: ResourceChangeLine = $MoneyChange
+@onready var fuel_change_display: ResourceChangeLine = $FuelChange
+
+@onready var start_position: Vector2 = position
+
+func set_combat_results(health_change: int, money_change: int, fuel_change: int):
+    health_change_display.set_change_amount(health_change)
+    money_change_display.set_change_amount(money_change)
+    fuel_change_display.set_change_amount(fuel_change)
+
+func display_combat_results():
+    show()
+    modulate = Color.WHITE
+    position = start_position
+
+    var display_tween: Tween = create_tween()
+    display_tween.tween_property(self, "modulate", Color.TRANSPARENT, DISPLAY_DURATION)
+    display_tween.parallel().tween_property(self, "position", start_position + FLOAT_OFFSET, DISPLAY_DURATION)
+    display_tween.tween_callback(hide)

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/combat_results_summary.tscn
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/combat_results_summary.tscn
@@ -1,0 +1,36 @@
+[gd_scene load_steps=6 format=3 uid="uid://cnphrbnb2wrnf"]
+
+[ext_resource type="PackedScene" uid="uid://jg6d8x31qb6t" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/resource_change_line.tscn" id="1_0ym2h"]
+[ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/combat_results_summary.gd" id="1_ogv1q"]
+[ext_resource type="Texture2D" uid="uid://bu66la2403v7p" path="res://assets/art/HEAL_icon_64x64.png" id="2_gf5uu"]
+[ext_resource type="Texture2D" uid="uid://dqfvwly0xyo0k" path="res://assets/art/tiny_silver_coin.png" id="3_d7sk3"]
+[ext_resource type="Texture2D" uid="uid://dmhymsa3he1w6" path="res://assets/art/energy_icon.png" id="4_id32d"]
+
+[node name="CombatResultsSummary" type="VBoxContainer"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -89.5
+offset_top = -11.5
+offset_right = 89.5
+offset_bottom = 11.5
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_ogv1q")
+
+[node name="HealthChange" parent="." instance=ExtResource("1_0ym2h")]
+layout_mode = 2
+texture = ExtResource("2_gf5uu")
+resource_name = "Health"
+
+[node name="MoneyChange" parent="." instance=ExtResource("1_0ym2h")]
+layout_mode = 2
+texture = ExtResource("3_d7sk3")
+resource_name = "Coin"
+
+[node name="FuelChange" parent="." instance=ExtResource("1_0ym2h")]
+layout_mode = 2
+texture = ExtResource("4_id32d")
+resource_name = "Fuel"

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/resource_change_line.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/resource_change_line.gd
@@ -1,7 +1,7 @@
 class_name ResourceChangeLine extends HBoxContainer
 
 const INCREASE_FORMAT = "+%s"
-const DECREASE_FORMAT = "-%s"
+const DECREASE_FORMAT = "%s" # Negative numbers already have - symbol
 
 @export var texture: Texture2D = preload("res://icon.svg")
 @export var resource_name: String = "ResourceName"
@@ -17,9 +17,11 @@ func _ready() -> void:
 
 func set_change_amount(change_amount: int) -> void:
     if change_amount > 0:
+        change_label.modulate = Color.WHITE
         change_label.text = INCREASE_FORMAT % change_amount
         show()
     elif change_amount < 0:
+        change_label.modulate = Color.RED
         change_label.text = DECREASE_FORMAT % change_amount
         show()
     else:

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/resource_change_line.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/resource_change_line.gd
@@ -1,0 +1,26 @@
+class_name ResourceChangeLine extends HBoxContainer
+
+const INCREASE_FORMAT = "+%s"
+const DECREASE_FORMAT = "-%s"
+
+@export var texture: Texture2D = preload("res://icon.svg")
+@export var resource_name: String = "ResourceName"
+
+@onready var resource_icon: TextureRect = $ResourceIcon
+@onready var resource_label: Label = $ResourceName
+@onready var change_label: Label = $ChangeLabel
+
+func _ready() -> void:
+    resource_icon.texture = texture
+    resource_label.text = resource_name
+    change_label.text = ""
+
+func set_change_amount(change_amount: int) -> void:
+    if change_amount > 0:
+        change_label.text = INCREASE_FORMAT % change_amount
+        show()
+    elif change_amount < 0:
+        change_label.text = DECREASE_FORMAT % change_amount
+        show()
+    else:
+        hide()

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/resource_change_line.tscn
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/resource_change_line.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=3 format=3 uid="uid://jg6d8x31qb6t"]
+
+[ext_resource type="Texture2D" uid="uid://4nvogy60mpq3" path="res://icon.svg" id="1_3mib2"]
+[ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/resource_change_line.gd" id="1_diylt"]
+
+[node name="ResourceChangeLine" type="HBoxContainer"]
+script = ExtResource("1_diylt")
+
+[node name="ResourceIcon" type="TextureRect" parent="."]
+layout_mode = 2
+size_flags_horizontal = 0
+texture = ExtResource("1_3mib2")
+expand_mode = 3
+
+[node name="ResourceName" type="Label" parent="."]
+layout_mode = 2
+size_flags_horizontal = 2
+text = "ResourceName"
+
+[node name="ChangeLabel" type="Label" parent="."]
+layout_mode = 2
+size_flags_horizontal = 10
+text = "+XX"


### PR DESCRIPTION
It's mostly faded out because my timing was poor, but this adds floating text when combat is in cooldown to summarize the outcome of combat:
![image](https://github.com/user-attachments/assets/b97b5f3f-17a8-4b89-a467-14df7ea91288)
