### PR TITLE
Outside resource panel delay

### DIFF
--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
@@ -34,6 +34,12 @@ const REROLL_FAIL_DURATION = 2
 @onready var charge_button: Button = $BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay/PanelContainer/VBoxContainer/ChargeButton
 @onready var go_inside_button: Button = $GoInsideButton
 
+@onready var resource_displays: Array[ResourceDisplay] = [
+    $TopBar/Trackers/MoneyDisplay,
+    $TopBar/Trackers/FuelDisplay,
+    $BottomInfoDisplay/Center/TopEdge/FuelDisplayMini,
+]
+
 func _ready():
     _hide_warnings()
 
@@ -155,9 +161,19 @@ func _enable_interaction() -> void:
     crew_actions_display.enable_all()
     crew_member_selector.enable_all()
 
+## Want to save the "resource ticking up" stuff until after the elements are visible again.
+func increase_resource_update_delay() -> void:
+    for resource_display: ResourceDisplay in resource_displays:
+        resource_display.resource_change_start_delay = ChargeSequence.COOLDOWN_DURATION
+
+func unset_resource_update_delay() -> void:
+    for resource_display: ResourceDisplay in resource_displays:
+        resource_display.resource_change_start_delay = 0
+
 func _on_charge_start() -> void:
     print("HUD charge start")
     _disable_interaction()
+    increase_resource_update_delay()
 
 func _on_charge_warmup(duration: float) -> void:
     print("HUD charge warmup", duration)
@@ -176,4 +192,5 @@ func _on_charge_cooldown(duration: float) -> void:
     _charge_mode_fadein(duration)
 
 func _on_charge_finish() -> void:
+    unset_resource_update_delay()
     _enable_interaction()

--- a/game/src/shared_ui/resource_display/health_display.tscn
+++ b/game/src/shared_ui/resource_display/health_display.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://da57hkojchohp"]
 
-[ext_resource type="Theme" uid="uid://faamfnysmojx" path="res://assets/themes/health_display.tres" id="1_ayytc"]
+[ext_resource type="Theme" path="res://assets/themes/health_display.tres" id="1_ayytc"]
 
 [node name="HealthDisplay" type="PanelContainer"]
 theme = ExtResource("1_ayytc")

--- a/game/src/shared_ui/resource_display/resource_display.gd
+++ b/game/src/shared_ui/resource_display/resource_display.gd
@@ -5,6 +5,7 @@ const MIN_DURATION: float = .1
 const COLOR_CHANGE_DURATION: float = 2
 
 @export var unit_change_per_second: int = 30
+@export var resource_change_start_delay: float = 0
 @export var COLOR_INCREASE: Color = Color.GREEN
 @export var COLOR_DECREASE: Color = Color.DARK_ORANGE
 @export var COLOR_INSUFFICIENT: Color = Color.RED
@@ -12,7 +13,7 @@ const COLOR_CHANGE_DURATION: float = 2
 @onready var database: Database = $"/root/Database"
 @onready var amount_label: Label = $MarginContainer/HBoxContainer/Amount
 
-var start_position: Vector2
+var label_start_position: Vector2
 var current_display_value: int:
     set(new_value):
         current_display_value = new_value
@@ -24,13 +25,13 @@ var position_tween: Tween
 ## children are responsible for connecting "value_changed" events and setting inital amount
 func _ready() -> void:
     await get_tree().process_frame
-    start_position = position
+    label_start_position = amount_label.position
 
 func force_display_resolution():
     if value_tween != null and value_tween.is_running():
-        value_tween.custom_step(MAX_DURATION)
+        value_tween.custom_step(resource_change_start_delay + MAX_DURATION)
     if color_tween != null and color_tween.is_running():
-        color_tween.custom_step(COLOR_CHANGE_DURATION)
+        color_tween.custom_step(resource_change_start_delay + COLOR_CHANGE_DURATION)
     if position_tween != null and position_tween.is_valid():
         position_tween.custom_step(MAX_DURATION)
 
@@ -43,10 +44,10 @@ func _create_position_tween():
         position_tween.stop()
     position_tween = create_tween()
     position_tween.tween_method(shake_display, 0, 0, .1)
-    position_tween.tween_property(self, "position", start_position, 0)
+    position_tween.tween_property(amount_label, "position", label_start_position, 0)
 
 func shake_display(_value: float):
-    position = start_position + (Vector2.ONE.rotated(randf_range(0, 6.29)) * 5)
+    amount_label.position = label_start_position + (Vector2.ONE.rotated(randf_range(0, 6.29)) * 5)
 
 func _on_resource_changed(new_value, old_value) -> void:
     _set_up_value_tween(new_value)
@@ -61,6 +62,7 @@ func _set_up_color_tween(color: Color) -> void:
     color_tween = create_tween()
     color_tween.set_ease(Tween.EASE_OUT)
     color_tween.set_trans(Tween.TRANS_CUBIC)
+    color_tween.tween_interval(resource_change_start_delay)
     color_tween.tween_property(amount_label, "modulate", Color.WHITE, COLOR_CHANGE_DURATION)
 
 func _set_up_value_tween(new_money_value) -> void:
@@ -72,6 +74,7 @@ func _set_up_value_tween(new_money_value) -> void:
     value_tween = create_tween()
     value_tween.set_ease(Tween.EaseType.EASE_OUT)
     value_tween.set_trans(Tween.TransitionType.TRANS_CUBIC)
+    value_tween.tween_interval(resource_change_start_delay)
     value_tween.tween_property(self, "current_display_value", new_money_value, duration)
     
 func _calculate_value_tween_duration(old_value: int, new_value: int) -> float:

--- a/game/src/shared_ui/resource_display/resource_display.gd
+++ b/game/src/shared_ui/resource_display/resource_display.gd
@@ -5,7 +5,6 @@ const MIN_DURATION: float = .1
 const COLOR_CHANGE_DURATION: float = 2
 
 @export var unit_change_per_second: int = 30
-@export var resource_change_start_delay: float = 0
 @export var COLOR_INCREASE: Color = Color.GREEN
 @export var COLOR_DECREASE: Color = Color.DARK_ORANGE
 @export var COLOR_INSUFFICIENT: Color = Color.RED
@@ -21,6 +20,7 @@ var current_display_value: int:
 var value_tween: Tween
 var color_tween: Tween
 var position_tween: Tween
+var resource_change_start_delay: float = 0
 
 ## children are responsible for connecting "value_changed" events and setting inital amount
 func _ready() -> void:
@@ -57,12 +57,14 @@ func _on_resource_changed(new_value, old_value) -> void:
 func _set_up_color_tween(color: Color) -> void:
     if color_tween != null and color_tween.is_running():
         color_tween.stop()
+
+    var modulate_callable: Callable = func(target): target.modulate = color
     
-    amount_label.modulate = color
     color_tween = create_tween()
     color_tween.set_ease(Tween.EASE_OUT)
     color_tween.set_trans(Tween.TRANS_CUBIC)
     color_tween.tween_interval(resource_change_start_delay)
+    color_tween.tween_callback(modulate_callable.bind(amount_label))
     color_tween.tween_property(amount_label, "modulate", Color.WHITE, COLOR_CHANGE_DURATION)
 
 func _set_up_value_tween(new_money_value) -> void:


### PR DESCRIPTION
Delays the visual increase / decrease of resource panels in outdoors scene until we're done fading back in from the charge scene.

This could have been done in a variety of ways (like by stopping their processing) but this seemed like a reasonable solution. We'll see if it makes anything trickier down the road.

To test, do a charge then observe when the changes to resource panels are displayed.