### PR TITLE
SFX - Hook Outdoors Buttons Back Up to Audio

### DIFF
--- a/game/src/audio_manager/audio_manager.gd
+++ b/game/src/audio_manager/audio_manager.gd
@@ -48,9 +48,6 @@ func _on_browse_new_hires_button_mouse_entered():
 func _on_character_info_panel_close_button_mouse_entered():
     SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
 
-func _on_charge_button_mouse_entered():
-    SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
-
 func _on_close_screen_notification_button_mouse_entered():
     SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
 
@@ -58,9 +55,6 @@ func _on_crew_member_detail_exit_button_mouse_entered():
     SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
 
 func _on_exit_button_mouse_entered():
-    SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
-
-func _on_go_inside_button_mouse_entered():
     SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
 
 func _on_go_outside_button_mouse_entered():
@@ -82,9 +76,6 @@ func _on_purchase_button_mouse_entered():
     SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
 
 func _on_quit_button_mouse_entered():
-    SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
-
-func _on_reroll_button_mouse_entered():
     SoundManager.play_ui_sound(sfx_button_hover, _bus_name_sfx_ui)
 
 func _on_reset_to_defaults_button_mouse_entered():

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=20 format=3 uid="uid://b6k6baalu42w7"]
+[gd_scene load_steps=21 format=3 uid="uid://b6k6baalu42w7"]
 
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd" id="1_3j823"]
 [ext_resource type="PackedScene" uid="uid://da57hkojchohp" path="res://src/shared_ui/resource_display/health_display.tscn" id="2_6fssr"]
+[ext_resource type="PackedScene" uid="uid://h1fowbxngb70" path="res://src/audio_manager/AudioManager.tscn" id="2_ffis0"]
 [ext_resource type="LabelSettings" uid="uid://2bu6p3hkt8lk" path="res://assets/label_settings/ColorWarning.tres" id="2_p0vkd"]
 [ext_resource type="PackedScene" uid="uid://cnbbp4gy833n" path="res://src/shared_ui/resource_display/money_display.tscn" id="2_ualkn"]
-[ext_resource type="PackedScene" path="res://src/shared_ui/resource_display/fuel_display.tscn" id="3_n5xb3"]
+[ext_resource type="PackedScene" uid="uid://cjb6144n5q1b1" path="res://src/shared_ui/resource_display/fuel_display.tscn" id="3_n5xb3"]
 [ext_resource type="PackedScene" uid="uid://cib1fq003l5jx" path="res://src/indoor_preparation/screen_displays/shared/screen_notification.tscn" id="3_rl23t"]
 [ext_resource type="PackedScene" uid="uid://cf5qy6u2j3hhw" path="res://assets/themes/fuel_display_mini.tscn" id="5_3m24g"]
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/crew_selector/crew_member_selector.gd" id="5_vpr4d"]
@@ -16,7 +17,7 @@
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/reroll_button.gd" id="7_xg4o8"]
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/total_power_display.gd" id="9_cb4ss"]
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/barrier_preview.gd" id="9_iui7q"]
-[ext_resource type="PackedScene" uid="uid://vnu6f53bf3ur" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/character_info_panel.tscn" id="16_oou66"]
+[ext_resource type="PackedScene" uid="uid://6tyicfyiq5gf" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/character_info_panel.tscn" id="16_oou66"]
 [ext_resource type="PackedScene" uid="uid://cnphrbnb2wrnf" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/combat_results_summary.tscn" id="18_lgpuc"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_8a5xg"]
@@ -35,6 +36,8 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_3j823")
+
+[node name="AudioManager" parent="." instance=ExtResource("2_ffis0")]
 
 [node name="TopBar" type="MarginContainer" parent="."]
 layout_mode = 0
@@ -512,5 +515,11 @@ anchor_top = 0.4
 anchor_bottom = 0.4
 grow_vertical = 0
 
+[connection signal="mouse_entered" from="BottomInfoDisplay/Center/TopEdge/RerollButton" to="AudioManager" method="_on_reroll_button_mouse_entered"]
 [connection signal="pressed" from="BottomInfoDisplay/Center/TopEdge/RerollButton" to="." method="_on_mock_reroll_button_pressed"]
+[connection signal="pressed" from="BottomInfoDisplay/Center/TopEdge/RerollButton" to="AudioManager" method="_on_reroll_button_pressed"]
+[connection signal="mouse_entered" from="BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay/PanelContainer/VBoxContainer/ChargeButton" to="AudioManager" method="_on_charge_button_mouse_entered"]
 [connection signal="pressed" from="BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay/PanelContainer/VBoxContainer/ChargeButton" to="." method="_on_mock_attack_button_pressed"]
+[connection signal="pressed" from="BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay/PanelContainer/VBoxContainer/ChargeButton" to="AudioManager" method="_on_charge_button_pressed"]
+[connection signal="mouse_entered" from="GoInsideButton" to="AudioManager" method="_on_go_inside_button_mouse_entered"]
+[connection signal="pressed" from="GoInsideButton" to="AudioManager" method="_on_go_inside_button_pressed"]

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn
@@ -515,11 +515,11 @@ anchor_top = 0.4
 anchor_bottom = 0.4
 grow_vertical = 0
 
-[connection signal="mouse_entered" from="BottomInfoDisplay/Center/TopEdge/RerollButton" to="AudioManager" method="_on_reroll_button_mouse_entered"]
+[connection signal="mouse_entered" from="BottomInfoDisplay/Center/TopEdge/RerollButton" to="." method="_on_reroll_button_mouse_entered"]
 [connection signal="pressed" from="BottomInfoDisplay/Center/TopEdge/RerollButton" to="." method="_on_mock_reroll_button_pressed"]
 [connection signal="pressed" from="BottomInfoDisplay/Center/TopEdge/RerollButton" to="AudioManager" method="_on_reroll_button_pressed"]
-[connection signal="mouse_entered" from="BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay/PanelContainer/VBoxContainer/ChargeButton" to="AudioManager" method="_on_charge_button_mouse_entered"]
+[connection signal="mouse_entered" from="BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay/PanelContainer/VBoxContainer/ChargeButton" to="." method="_on_charge_button_mouse_entered"]
 [connection signal="pressed" from="BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay/PanelContainer/VBoxContainer/ChargeButton" to="." method="_on_mock_attack_button_pressed"]
 [connection signal="pressed" from="BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay/PanelContainer/VBoxContainer/ChargeButton" to="AudioManager" method="_on_charge_button_pressed"]
-[connection signal="mouse_entered" from="GoInsideButton" to="AudioManager" method="_on_go_inside_button_mouse_entered"]
+[connection signal="mouse_entered" from="GoInsideButton" to="." method="_on_go_inside_button_mouse_entered"]
 [connection signal="pressed" from="GoInsideButton" to="AudioManager" method="_on_go_inside_button_pressed"]

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
@@ -142,7 +142,9 @@ func _charge_mode_fadeout(duration: float) -> void:
         top_bar_display,
     ]
     for target: Control in fadeout_targets:
-        create_tween().tween_property(target, "modulate", Color.TRANSPARENT, duration)
+        var fadeout_tween: Tween = create_tween()
+        fadeout_tween.tween_property(target, "modulate", Color.TRANSPARENT, duration)
+        fadeout_tween.tween_callback(target.hide)
     
 func _charge_mode_fadein(duration: float) -> void:
     var fadein_targets: Array[Control] = [
@@ -152,7 +154,9 @@ func _charge_mode_fadein(duration: float) -> void:
         top_bar_display,
     ]
     for target: Control in fadein_targets:
-        create_tween().tween_property(target, "modulate", Color.WHITE, duration)
+        var fadein_tween: Tween = create_tween()
+        fadein_tween.tween_callback(target.show)
+        fadein_tween.tween_property(target, "modulate", Color.WHITE, duration)
 
 func _enable_interaction() -> void:
     reroll_button._set_disabled(false)

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
@@ -6,6 +6,7 @@ signal dice_roll_requested
 const REROLL_FAIL_MESSAGE = "Failed to shuffle unlocked actions.\nReason: INSUFFICIENT_FUEL"
 const REROLL_FAIL_DURATION = 2
 
+@onready var audio_manager: AudioManager = $AudioManager
 #@onready var barriers = $TopBar/Trackers/BarriersOvercomeTracker/Current
 @onready var combat_math_formulas = CombatMathFormulas.new()
 @onready var health_current = $TopBar/Trackers/HealthDisplay/MarginContainer/HBoxContainer/HealthCurrent
@@ -203,3 +204,26 @@ func _on_charge_cooldown(duration: float) -> void:
 func _on_charge_finish() -> void:
     unset_resource_update_delay()
     _enable_interaction()
+
+
+#region Descendant SFX: enabled button mouse entered
+
+func _on_charge_button_mouse_entered():
+    if charge_button.disabled:
+        return
+
+    audio_manager.on_enabled_button_mouse_entered()
+
+func _on_go_inside_button_mouse_entered():
+    if go_inside_button.disabled:
+        return
+
+    audio_manager.on_enabled_button_mouse_entered()
+
+func _on_reroll_button_mouse_entered():
+    if reroll_button.disabled:
+        return
+
+    audio_manager.on_enabled_button_mouse_entered()
+
+#endregion Descendant SFX: enabled button mouse entered

--- a/game/src/indoor_preparation/screen_displays/shared/upgrades/upgrade_cost_prompt.gd
+++ b/game/src/indoor_preparation/screen_displays/shared/upgrades/upgrade_cost_prompt.gd
@@ -70,12 +70,16 @@ func clear_upgrade_data():
     previewed_upgrade = null
     update_display_elements(false, false)
 
+func _on_purchase_button_pressed():
+    upgrade_purchase_pressed.emit(selected_upgrade)
+
+
+#region Descendant SFX: enabled button mouse entered
+
 func _on_purchase_button_mouse_entered():
-    # Guardian check to only play a hover sound effect for an enabled button.
     if purchase_button.disabled:
         return
 
     audio_manager.on_enabled_button_mouse_entered()
 
-func _on_purchase_button_pressed():
-    upgrade_purchase_pressed.emit(selected_upgrade)
+#endregion Descendant SFX: enabled button mouse entered


### PR DESCRIPTION
Hook 3 buttons on the gameplay outdoors screen back up to SFX.

## Implementation Details

The buttons fixed are:

- Manage Crew Inside
- Reroll
- Charge!

Also prevent 4 buttons from playing a `mouse_entered()` sound effect while disabled.

### Screenshot

![pr-61_fixed-buttons](https://github.com/user-attachments/assets/846f11e1-9ab4-4937-8b54-e433b593b048)
_**Screenshot 1:** The gameplay outdoors' 3 fixed buttons are circled in red._