### PR TITLE
Auto reroll after charge

### DIFF
--- a/game/assets/data/database.gd
+++ b/game/assets/data/database.gd
@@ -306,6 +306,11 @@ func set_die_slot_frozen_status(character: Character, new_freeze: bool) -> void:
     die_slot.is_frozen = new_freeze
     die_slot_changed.emit(die_slot)
 
+func clear_all_frozen_status() -> void:
+    for die_slot: CharacterDieSlot in current_character_die_slots:
+        die_slot.is_frozen = false
+        die_slot_changed.emit(die_slot)
+
 func _ready_audio_volumes() -> void:
     set_audio_volume_initialized(false)
     set_audio_volume_music(_initial_audio_volume_music)

--- a/game/src/battlefield_outdoors/battlefield_outdoors.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors.gd
@@ -126,9 +126,11 @@ func _on_charge_cooldown(duration: float) -> void:
     war_transport.hide_power(duration)
     war_transport.return_to_start_position(duration)
     _generate_and_scale_next_barrier()
-    # clear all dice frozen status, put display in rerolling prep
+    # clear all dice frozen status
+    battlefield_outdoors_hud.request_roll_preview_start()
 
 func _on_charge_finish() -> void:
+    battlefield_outdoors_hud.request_roll_preview_stop()
     const free_reroll_cost = 0
     _on_roll_requested(free_reroll_cost)
     if _should_save_checkpoint():

--- a/game/src/battlefield_outdoors/battlefield_outdoors.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors.gd
@@ -127,16 +127,20 @@ func _on_charge_cooldown(duration: float) -> void:
     war_transport.return_to_start_position(duration)
     _generate_and_scale_next_barrier()
     # clear all dice frozen status
+    Database.clear_all_frozen_status()
     battlefield_outdoors_hud.request_roll_preview_start()
 
 func _on_charge_finish() -> void:
     battlefield_outdoors_hud.request_roll_preview_stop()
     const free_reroll_cost = 0
     _on_roll_requested(free_reroll_cost)
+
     if _should_save_checkpoint():
         _save_checkpoint()
-    combat_result.clear()
+
     barrier.new_barrier_scroll_onscreen(2, Vector2(500, 0))
+
+    combat_result.clear()
 
 func _generate_and_scale_next_barrier() -> void:
     var new_barrier: BarrierData = _generate_barrier_data()

--- a/game/src/battlefield_outdoors/battlefield_outdoors.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors.gd
@@ -126,8 +126,11 @@ func _on_charge_cooldown(duration: float) -> void:
     war_transport.hide_power(duration)
     war_transport.return_to_start_position(duration)
     _generate_and_scale_next_barrier()
+    # clear all dice frozen status, put display in rerolling prep
 
 func _on_charge_finish() -> void:
+    const free_reroll_cost = 0
+    _on_roll_requested(free_reroll_cost)
     if _should_save_checkpoint():
         _save_checkpoint()
     combat_result.clear()
@@ -184,14 +187,15 @@ func _on_health_empty() -> void:
     game_over_sequence.tween_callback(
         get_tree().change_scene_to_packed.bind(preload("res://src/game_over/game_over.tscn")))
 
-func _on_roll_requested():
-    if _has_enough_fuel():
+func _on_roll_requested(override_cost: int = -1):
+    var roll_cost: int = override_cost if override_cost >= 0 else Database.current_reroll_fuel_cost
+    if _has_enough_fuel(roll_cost):
         dice_roll_started.emit()
-        Database.set_fuel(Database.current_fuel - Database.current_reroll_fuel_cost)
+        Database.set_fuel(Database.current_fuel - roll_cost)
         _roll_dice()
 
-func _has_enough_fuel() -> bool:
-    var enough_fuel: bool = Database.current_fuel >= Database.current_reroll_fuel_cost
+func _has_enough_fuel(cost: int) -> bool:
+    var enough_fuel: bool = Database.current_fuel >= cost
     if not enough_fuel:
         insufficient_fuel.emit()
     return enough_fuel

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
@@ -59,8 +59,8 @@ func _ready():
     character_info_panel.character_selected.connect(crew_member_selector._on_character_selected)
     character_info_panel.character_selected.connect(crew_actions_display._on_character_selected)
 
-    reroll_button.hovered_available_reroll.connect(crew_actions_display._start_preview_reroll)
-    reroll_button.exited_available_reroll.connect(crew_actions_display._stop_preview_reroll)
+    reroll_button.hovered_available_reroll.connect(crew_actions_display.start_preview_reroll)
+    reroll_button.exited_available_reroll.connect(crew_actions_display.stop_preview_reroll)
  
     charge_button.pressed.connect(initiate_charge_requested.emit)
 
@@ -76,6 +76,12 @@ func _hide_roll_warnings() -> void:
 
 func _on_mock_attack_button_pressed() -> void:
     _hide_roll_warnings()
+
+func request_roll_preview_start() -> void:
+    crew_actions_display.start_preview_reroll()
+
+func request_roll_preview_stop() -> void:
+    crew_actions_display.stop_preview_reroll()
 
 func _on_mock_reroll_button_pressed() -> void:
     if Database.war_transport_health_current <= 0:

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_actions_display.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_actions_display.gd
@@ -31,7 +31,7 @@ func _on_character_selected(selected_character: Character, button_end_state: boo
         else:
             action_display.button.button_pressed = false
 
-func _start_preview_reroll() -> void:
+func start_preview_reroll() -> void:
     var any_unfrozen: bool = false
     for action_display in action_displays:
         action_display.set_rolling_display(true)
@@ -42,7 +42,7 @@ func _start_preview_reroll() -> void:
     if any_unfrozen:
         dice_visually_rolling_start.emit()
 
-func _stop_preview_reroll() -> void:
+func stop_preview_reroll() -> void:
     for action_display in action_displays:
         action_display.set_rolling_display(false)
 


### PR DESCRIPTION
Does what it says - clears frozen status, rerolls dice at the start of each new round.

What's extra cool is that the way the code was reused automatically gave us visuals and sound effects to accompany the dice-rolling for free!

check it out today!