### PR TITLE
Batch applicants

### DIFF
--- a/game/assets/data/database.gd
+++ b/game/assets/data/database.gd
@@ -29,6 +29,7 @@ static var stat_type_to_icon: Dictionary = {
 
 const CHECKPOINT_SAVED_MESSAGE: String = "Checkpoint Reached!"
 const CHECKPOINT_SAVED_DURATION: float = 2
+const MAX_APPLICANTS: int = 4
 
 const _settings_default_audio_volume_music: float = 0.5
 const _settings_default_audio_volume_sfx: float = 0.5

--- a/game/assets/data/database.gd
+++ b/game/assets/data/database.gd
@@ -172,7 +172,7 @@ func initialize_characters() -> void:
         else:
             unhired_characters.append(characters[i])
     
-    hire_character(get_random_unhired(1)[0])
+    #hire_character(get_random_unhired(1)[0])
     initialize_missing_die_slots()
 
 func initialize_missing_die_slots() -> void:

--- a/game/assets/data/database.gd
+++ b/game/assets/data/database.gd
@@ -4,6 +4,7 @@ extends Node
 signal health_changed(new_value: int, old_value: int)
 signal money_changed(new_value: int, old_value: int)
 signal fuel_changed(new_value: int, old_value: int)
+signal applicant_count_changed(new_value: int, old_value: int)
 signal die_slots_set(was_reroll: bool)
 signal die_slot_changed(changed_die_slot: CharacterDieSlot)
 signal barrier_changed(new_barrier_data: BarrierData)
@@ -135,7 +136,7 @@ func load_from_init_values(init_values: GameplayInitValues):
 
     hired_characters = init_values.hired_characters
     unhired_characters = init_values.unhired_characters
-    applicants = init_values.applicants
+    set_current_applicants(applicants)
     should_generate_new_applicants = init_values.should_generate_new_applicants
 
 # Excludes chosen settings for audio volume.
@@ -165,14 +166,13 @@ func initialize_characters() -> void:
     var characters: Array = _character_factories.map(func(x): return x.instantiate())
     hired_characters = []
     unhired_characters = []
-    applicants = []
+    set_current_applicants([])
     for i in range(characters.size()):
         if i in _starting_character_idxs:
             hired_characters.append(characters[i])
         else:
             unhired_characters.append(characters[i])
     
-    #hire_character(get_random_unhired(1)[0])
     initialize_missing_die_slots()
 
 func initialize_missing_die_slots() -> void:
@@ -216,11 +216,14 @@ func get_random_unhired(count: int) -> Array[Character]:
         return selected_characters
 
 func set_current_applicants(new_applicants: Array[Character]) -> void:
+    var old_count = applicants.size()
     applicants = new_applicants
+    applicant_count_changed.emit(new_applicants.size(), old_count)
 
 func hire_character(character: Character) -> void:
     unhired_characters.erase(character)
     applicants.erase(character)
+    set_current_applicants(applicants)
     hired_characters.append(character)
 
 func get_settings_default_audio_volume_music() -> float:

--- a/game/src/battlefield_outdoors/battlefield_outdoors.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors.gd
@@ -228,6 +228,6 @@ func _on_checkpoint_saved() -> void:
 func _on_new_applicants_arrived() -> void:
     battlefield_outdoors_hud.screen_notification.queue_notification(
         ScreenNotification.ScreenNotificationType.NOTIFY,
-        ApplicantOrchestrator.NEW_APPLICANTS_MESSAGE,
+        ApplicantOrchestrator.NEW_APPLICANTS_MESSAGE % Database.applicants.size(),
         ApplicantOrchestrator.NEW_APPLICANTS_DURATION,
     )

--- a/game/src/battlefield_outdoors/battlefield_outdoors.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors.gd
@@ -219,8 +219,15 @@ func _roll_dice() -> void:
     Database.set_current_character_die_slots(character_die_slots, true)
 
 func _on_checkpoint_saved() -> void:
-    battlefield_outdoors_hud.screen_notification.display_notification(
+    battlefield_outdoors_hud.screen_notification.queue_notification(
         ScreenNotification.ScreenNotificationType.CHECKPOINT,
         Database.CHECKPOINT_SAVED_MESSAGE,
         Database.CHECKPOINT_SAVED_DURATION
+    )
+
+func _on_new_applicants_arrived() -> void:
+    battlefield_outdoors_hud.screen_notification.queue_notification(
+        ScreenNotification.ScreenNotificationType.NOTIFY,
+        ApplicantOrchestrator.NEW_APPLICANTS_MESSAGE,
+        ApplicantOrchestrator.NEW_APPLICANTS_DURATION,
     )

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=3 uid="uid://b6k6baalu42w7"]
+[gd_scene load_steps=22 format=3 uid="uid://b6k6baalu42w7"]
 
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd" id="1_3j823"]
 [ext_resource type="PackedScene" uid="uid://da57hkojchohp" path="res://src/shared_ui/resource_display/health_display.tscn" id="2_6fssr"]
@@ -19,6 +19,7 @@
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/barrier_preview.gd" id="9_iui7q"]
 [ext_resource type="PackedScene" uid="uid://vnu6f53bf3ur" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/character_info_panel.tscn" id="16_oou66"]
 [ext_resource type="PackedScene" uid="uid://cnphrbnb2wrnf" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/combat_results_summary.tscn" id="18_lgpuc"]
+[ext_resource type="PackedScene" uid="uid://b5yq7dbetb72t" path="res://src/shared_ui/resource_display/applicants_display.tscn" id="18_pekm7"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_8a5xg"]
 content_margin_left = 5.0
@@ -491,6 +492,17 @@ offset_bottom = 8.0
 grow_horizontal = 2
 text = "Manage Crew
 Inside "
+
+[node name="ApplicantsDisplay" parent="GoInsideButton" instance=ExtResource("18_pekm7")]
+visible = false
+modulate = Color(1, 1, 1, 0)
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = 5.0
+offset_right = 179.0
+offset_bottom = 29.0
 
 [node name="CharacterInfoPanel" parent="." instance=ExtResource("16_oou66")]
 visible = false

--- a/game/src/gameplay/Gameplay.tscn
+++ b/game/src/gameplay/Gameplay.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=8 format=3 uid="uid://1wye34y7qnhe"]
+[gd_scene load_steps=9 format=3 uid="uid://1wye34y7qnhe"]
 
 [ext_resource type="PackedScene" uid="uid://mq5u7di7yh8m" path="res://src/back_to_start_menu_button/BackToStartMenuButton.tscn" id="1_8sw2a"]
 [ext_resource type="Script" path="res://src/gameplay/gameplay.gd" id="1_exjrn"]
 [ext_resource type="Theme" uid="uid://dk5iv042psfw" path="res://assets/themes/Default.tres" id="1_hbifn"]
 [ext_resource type="PackedScene" uid="uid://c5dvnfrvyjol6" path="res://src/battlefield_outdoors/BattlefieldOutdoors.tscn" id="2_35wcq"]
+[ext_resource type="Script" path="res://src/hiring/applicant_orchestrator.gd" id="3_mkluk"]
 [ext_resource type="PackedScene" uid="uid://h1fowbxngb70" path="res://src/audio_manager/AudioManager.tscn" id="3_o8xt6"]
 [ext_resource type="PackedScene" uid="uid://b73yb04wjxq8" path="res://src/indoor_preparation/indoor_preparation.tscn" id="4_qkdrp"]
 [ext_resource type="PackedScene" uid="uid://cqks4bltxh7sq" path="res://src/transition_cover/mode_transition_cover.tscn" id="6_blf36"]
@@ -17,6 +18,9 @@ grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_hbifn")
 script = ExtResource("1_exjrn")
+
+[node name="ApplicantOrchestrator" type="Node" parent="."]
+script = ExtResource("3_mkluk")
 
 [node name="AudioManager" parent="." instance=ExtResource("3_o8xt6")]
 

--- a/game/src/gameplay/gameplay.gd
+++ b/game/src/gameplay/gameplay.gd
@@ -2,6 +2,7 @@ class_name Gameplay extends Control
 
 signal checkpoint_saved()
 
+@onready var applicant_orchestrator: ApplicantOrchestrator = $ApplicantOrchestrator
 @onready var outdoor_canvas: CanvasLayer = $OutdoorBattleMode
 @onready var outdoor_root: BattlefieldOutdoors = $OutdoorBattleMode/BattlefieldOutdoors
 @onready var indoor_canvas: CanvasLayer = $IndoorPrepMode
@@ -19,9 +20,14 @@ func _ready() -> void:
     outdoor_root.charge_warmup.connect(charge_zoom_in)
     outdoor_root.charge_cooldown.connect(charge_zoom_out)
 
+    outdoor_root.charge_finish.connect(applicant_orchestrator.update_applicants)
+
     Database.checkpoint_saved.connect(checkpoint_saved.emit)
     checkpoint_saved.connect(outdoor_root._on_checkpoint_saved)
     checkpoint_saved.connect(indoor_root._on_checkpoint_saved)
+
+    applicant_orchestrator.new_applicants_arrived.connect(outdoor_root._on_new_applicants_arrived)
+    applicant_orchestrator.new_applicants_arrived.connect(indoor_root._on_new_applicants_arrived)
 
 func go_inside() -> void:
     # we can do fancier stuff, like take a callback to only do once the screen's 

--- a/game/src/hiring/applicant_orchestrator.gd
+++ b/game/src/hiring/applicant_orchestrator.gd
@@ -10,7 +10,7 @@ var rounds_since_last_applicant: int = 0
 var rounds_since_applicant_left: int = 0
 
 func _ready() -> void:
-    rounds_since_last_applicant = 4
+    rounds_since_last_applicant = 10 - min(4, Database.barriers_overcome_count)
 
 func update_applicants():
     var current_round: int = Database.barriers_overcome_count

--- a/game/src/hiring/applicant_orchestrator.gd
+++ b/game/src/hiring/applicant_orchestrator.gd
@@ -82,7 +82,29 @@ func _calculate_applicant_count(current_round: int, crew_size: int) -> int:
     return applicant_count
 
 func _select_new_applicants(count: int) -> Array[Character]:
-    return []
+    var unhired_characters: Array[Character] = Database.unhired_characters
+    var current_applicants: Array[Character] = Database.applicants
+
+    var available_characters: Array[Character] = \
+        unhired_characters.filter(func(x): return x not in current_applicants)
+    
+    if count >= available_characters.size():
+        return available_characters
+    else:
+        var possible_indices: Array = range(available_characters.size())
+        var random_selections: Array[int] = []
+        for i in range(count):
+            var selected_index: int = possible_indices.pick_random()
+            if selected_index in random_selections:
+                selected_index = possible_indices.pick_random()
+            while selected_index in random_selections:
+                selected_index = (selected_index + 1) % available_characters.size()
+            random_selections.append(selected_index)
+        
+        var selected_characters: Array[Character] = []
+        for idx: int in random_selections:
+            selected_characters.append(available_characters[idx])
+        return selected_characters
 
 func _adjust_price(applicant: Character, current_round: int, crew_size: int) -> void:
     pass
@@ -90,4 +112,5 @@ func _adjust_price(applicant: Character, current_round: int, crew_size: int) -> 
 func _cycle_applicants(new_applicants: Array[Character],
         current_applicants: Array[Character]
         ) -> Array[Character]:
-    return []
+    new_applicants.append(current_applicants)
+    return new_applicants.slice(0, Database.MAX_APPLICANTS)

--- a/game/src/hiring/applicant_orchestrator.gd
+++ b/game/src/hiring/applicant_orchestrator.gd
@@ -10,7 +10,7 @@ var rounds_since_last_applicant: int = 0
 var rounds_since_applicant_left: int = 0
 
 func _ready() -> void:
-    rounds_since_last_applicant = 10
+    rounds_since_last_applicant = 4
 
 func update_applicants():
     var current_round: int = Database.barriers_overcome_count
@@ -83,7 +83,10 @@ func _pop_back_applicants(
         number_to_remove: int
         ) -> Array[Character]:
     
-    return current_applicants.slice(0, current_applicants.size() - number_to_remove)
+    if number_to_remove > current_applicants.size():
+        return []
+    else:
+        return current_applicants.slice(0, current_applicants.size() - number_to_remove)
 
 func _calculate_applicant_count(current_round: int, crew_size: int) -> int:
     const chance_per_time_crew_count_looped: float = .1

--- a/game/src/hiring/applicant_orchestrator.gd
+++ b/game/src/hiring/applicant_orchestrator.gd
@@ -1,0 +1,43 @@
+class_name ApplicantOrchestrator extends Node
+
+signal new_applicants_arrived(new_applicants: Array[Character])
+
+func update_applicants(current_round: int):
+    var current_applicants: Array[Character] = Database.applicants
+    var crew_size: int = Database.hired_character_count
+
+    if current_applicants.size() > 1:
+        var num_to_remove: int = _calculate_leave_count()
+        current_applicants = _pop_back_applicants(current_applicants, num_to_remove)
+    
+    var num_to_add: int = _calculate_applicant_count(current_round, crew_size)
+    if num_to_add > 0:
+        var new_applicants: Array[Character] = _select_new_applicants(num_to_add)
+        for applicant: Character in new_applicants:
+            _adjust_price(applicant, current_round, crew_size)
+        _cycle_applicants(new_applicants, current_applicants)
+
+        new_applicants_arrived.emit(new_applicants)
+
+func _calculate_leave_count() -> int:
+    return 0
+
+func _pop_back_applicants(
+        current_applicants: Array[Character],
+        number_to_remove: int
+        ) -> Array[Character]:
+    return []
+
+func _calculate_applicant_count(current_round: int, crew_size: int) -> int:
+    return 0
+
+func _select_new_applicants(count: int) -> Array[Character]:
+    return []
+
+func _adjust_price(applicant: Character, current_round: int, crew_size: int) -> void:
+    pass
+
+func _cycle_applicants(new_applicants: Array[Character],
+        current_applicants: Array[Character]
+        ) -> Array[Character]:
+    return []

--- a/game/src/indoor_preparation/indoor_preparation.gd
+++ b/game/src/indoor_preparation/indoor_preparation.gd
@@ -6,7 +6,6 @@ signal upgrade_success(character: Character)
 signal upgrade_failure(character: Character, reason: String)
 signal insufficient_funds()
 
-const APPLICANT_COUNT: int = 4
 const PURCHASE_FAIL_POOR_REASON: String = "INSUFFICIENT_FUNDS"
 
 @onready var database: Database = $"/root/Database"
@@ -34,12 +33,7 @@ func _ready() -> void:
 
 func transition_in() -> void:
     process_mode = PROCESS_MODE_INHERIT
-    if database.should_generate_new_applicants:
-        applicants = database.get_random_unhired(APPLICANT_COUNT)
-        database.set_current_applicants(applicants)
-        database.should_generate_new_applicants = false
-    else:
-        applicants = database.applicants
+    applicants = database.applicants
     
     screen.register_applicants_for_display(applicants)
     screen.return_to_home_display()
@@ -74,3 +68,6 @@ func _on_upgrade_purchase_attempted(character: Character, upgrade_choice: Upgrad
 
 func _on_checkpoint_saved() -> void:
     screen.on_checkpoint_saved()
+
+func _on_new_applicants_arrived() -> void:
+    screen.on_new_applicants_arrived()

--- a/game/src/indoor_preparation/screen.gd
+++ b/game/src/indoor_preparation/screen.gd
@@ -152,6 +152,15 @@ func on_checkpoint_saved():
         Database.CHECKPOINT_SAVED_DURATION
     )
 
+func on_new_applicants_arrived():
+    register_applicants_for_display(Database.applicants)
+    notification_dimmer.show()
+    screen_notification.display_notification(
+        ScreenNotification.ScreenNotificationType.NOTIFY,
+        ApplicantOrchestrator.NEW_APPLICANTS_MESSAGE,
+        ApplicantOrchestrator.NEW_APPLICANTS_DURATION,
+    )
+
 func _hide_all_screen_displays() -> void:
     home_display.hide()
     hire_preview_display.hide()

--- a/game/src/indoor_preparation/screen.gd
+++ b/game/src/indoor_preparation/screen.gd
@@ -157,7 +157,7 @@ func on_new_applicants_arrived():
     notification_dimmer.show()
     screen_notification.display_notification(
         ScreenNotification.ScreenNotificationType.NOTIFY,
-        ApplicantOrchestrator.NEW_APPLICANTS_MESSAGE,
+        ApplicantOrchestrator.NEW_APPLICANTS_MESSAGE % Database.applicants.size(),
         ApplicantOrchestrator.NEW_APPLICANTS_DURATION,
     )
 

--- a/game/src/indoor_preparation/screen.gd
+++ b/game/src/indoor_preparation/screen.gd
@@ -46,6 +46,7 @@ func _ready() -> void:
 
 func register_applicants_for_display(applicants: Array[Character]) -> void:
     hire_preview_display.set_new_applicants(applicants)
+    home_display.view_applicants_button.disabled = applicants.is_empty()
 
 func return_to_home_display() -> void:
     _cancel_notifications()
@@ -104,9 +105,14 @@ func _on_hiring_success(character: Character) -> void:
         HIRE_SUCCESS_FORMAT % character.name,
         HIRE_SUCCESS_DURATION
     )
-    screen_notification.notification_expired.connect(
-        _transition_to_hire_preview_display,
-        CONNECT_ONE_SHOT)
+    if Database.applicants.is_empty():
+        screen_notification.notification_expired.connect(
+            return_to_home_display,
+            CONNECT_ONE_SHOT)
+    else:
+        screen_notification.notification_expired.connect(
+            _transition_to_hire_preview_display,
+            CONNECT_ONE_SHOT)
 
 func _on_hiring_failure(character: Character, reason: String) -> void:
     notification_dimmer.show()

--- a/game/src/shared_ui/resource_display/applicants_display.gd
+++ b/game/src/shared_ui/resource_display/applicants_display.gd
@@ -1,0 +1,25 @@
+class_name ApplicantsDisplay extends ResourceDisplay
+
+var fade_tween: Tween
+
+func _ready() -> void:
+    super()
+    database.applicant_count_changed.connect(_on_resource_changed)
+    current_display_value = database.applicants.size()
+
+func _on_resource_changed(new_value, old_value):
+    super(new_value, old_value)
+
+    if new_value == 0 and visible:
+        if fade_tween != null and fade_tween.is_valid():
+            fade_tween.kill()
+        fade_tween = create_tween()
+        fade_tween.tween_property(self, "modulate", Color.TRANSPARENT, 2)
+        fade_tween.tween_callback(hide)
+
+    elif new_value != 0 and modulate != Color.WHITE:
+        if fade_tween != null and fade_tween.is_valid():
+            fade_tween.kill()
+        fade_tween = create_tween()
+        fade_tween.tween_callback(show)
+        fade_tween.tween_property(self, "modulate", Color.WHITE, 2)

--- a/game/src/shared_ui/resource_display/applicants_display.tscn
+++ b/game/src/shared_ui/resource_display/applicants_display.tscn
@@ -1,0 +1,37 @@
+[gd_scene load_steps=3 format=3 uid="uid://b5yq7dbetb72t"]
+
+[ext_resource type="PackedScene" uid="uid://cwx53f7dgoboq" path="res://src/shared_ui/resource_display/resource_display.tscn" id="1_43wy7"]
+[ext_resource type="Script" path="res://src/shared_ui/resource_display/applicants_display.gd" id="2_kie4s"]
+
+[node name="ApplicantsDisplay" instance=ExtResource("1_43wy7")]
+anchors_preset = 0
+anchor_left = 0.0
+anchor_right = 0.0
+offset_left = 0.0
+offset_right = 150.0
+offset_bottom = 25.0
+grow_horizontal = 1
+script = ExtResource("2_kie4s")
+
+[node name="MarginContainer" parent="." index="0"]
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="HBoxContainer" parent="MarginContainer" index="0"]
+size_flags_vertical = 4
+
+[node name="ResourceIcon" parent="MarginContainer/HBoxContainer" index="0"]
+visible = false
+
+[node name="Label" type="Label" parent="MarginContainer/HBoxContainer" index="1"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+text = "Open Applications:"
+
+[node name="Amount" parent="MarginContainer/HBoxContainer" index="2"]
+theme_override_font_sizes/font_size = 16
+horizontal_alignment = 1


### PR DESCRIPTION
The logic for when the game decides to give the player applicants is a little complicated, but the structure is simple - we can swap out the calculations for something simpler without much difficulty.

The basic principle is that you are more likely to get applicants if:
 * you haven't had any applicants in a while
 * the number of rounds is larger than the size of your crew
 * the round # is a multiple of 3 (just to give the game a little bit of a rhythm to it when the odds get lower)

Applicants will eventually leave too:
 * every turn that passes increases the chance the "oldest" (last in list) leaves. When someone does leave, the chance resets.
 * There's a 1 turn grace period after folks arrive before they can start leaving.

There's a display that pops up next to the "go inside" button to help you keep track of open applications. Helps avoid too much notification spam, and it fades out when there are no more applicants.