### PR TITLE
Update calc bug & barrier display bug

### DIFF
--- a/game/assets/data/database.gd
+++ b/game/assets/data/database.gd
@@ -147,6 +147,7 @@ func reset_values() -> void:
     set_current_barrier_stat_type_to_overcome(
         _initial_barriers_stat_type_to_overcome
     )
+    set_current_barrier_data(null)
     set_current_character_die_slots(_initial_character_die_slots.duplicate())
     set_current_matching_stat_type_multiplier(
         _initial_matching_stat_type_multiplier

--- a/game/src/battlefield_outdoors/battlefield_outdoors.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors.gd
@@ -217,6 +217,7 @@ func _roll_dice() -> void:
         character_die_slot.last_roll_result = character_die_slot.roll_action()
 
     Database.set_current_character_die_slots(character_die_slots, true)
+    battlefield_outdoors_hud.refresh_calculations()
 
 func _on_checkpoint_saved() -> void:
     battlefield_outdoors_hud.screen_notification.display_notification(

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/battlefield_outdoors_hud.gd
@@ -166,7 +166,11 @@ func _charge_mode_fadein(duration: float) -> void:
         fadein_tween.tween_property(target, "modulate", Color.WHITE, duration)
 
 func _enable_interaction() -> void:
-    reroll_button._set_disabled(false)
+    # delay added here to account for auto die roll
+    create_tween() \
+        .tween_callback(reroll_button._set_disabled.bind(false)) \
+        .set_delay(reroll_button.reroll_cooldown)
+    
     charge_button.disabled = false
     go_inside_button.disabled = false
     # fade in hud, more quickly this time


### PR DESCRIPTION
Also fixes a bug with reroll button that I discovered during work - previously, if you hovered mouse over reroll as the button became undisabled from combat it wouldn't make the noise. Happened because the timing issue of a roll & button becoming available at the same time, which wasn't possible before.

resolved by making the button not available for the usual duration after the roll. Method's a bit hacky but it's functional.