### PR TITLE
fixed bug where characters stay selected when exit / re-enter indoors

### DIFF
--- a/game/src/indoor_preparation/indoor_preparation.gd
+++ b/game/src/indoor_preparation/indoor_preparation.gd
@@ -40,6 +40,9 @@ func transition_in() -> void:
     screen.home_display.set_barrier(database.current_barrier_data)
     money_display.force_display_resolution()
 
+    for button: Button in (crew_buttons as Array[Button]):
+        button.button_pressed = false
+
 func transition_out() -> void:
     process_mode = PROCESS_MODE_DISABLED
 


### PR DESCRIPTION
Quick bugfix.

Previously if you went indoors, selected character, go outdoors, then go indoors the screen would be reset to "home" but the previously selected character would still be highlighted.

Try it out for yourself!