### PR TITLE
Dice on home screen

### DIFF
--- a/game/assets/data/database.gd
+++ b/game/assets/data/database.gd
@@ -226,6 +226,7 @@ func hire_character(character: Character) -> void:
     applicants.erase(character)
     set_current_applicants(applicants)
     hired_characters.append(character)
+    Database.initialize_missing_die_slots()
 
 func get_settings_default_audio_volume_music() -> float:
     return _settings_default_audio_volume_music

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/BattlefieldOutdoorsHud.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="PackedScene" uid="uid://h1fowbxngb70" path="res://src/audio_manager/AudioManager.tscn" id="2_ffis0"]
 [ext_resource type="LabelSettings" uid="uid://2bu6p3hkt8lk" path="res://assets/label_settings/ColorWarning.tres" id="2_p0vkd"]
 [ext_resource type="PackedScene" uid="uid://cnbbp4gy833n" path="res://src/shared_ui/resource_display/money_display.tscn" id="2_ualkn"]
-[ext_resource type="PackedScene" uid="uid://cjb6144n5q1b1" path="res://src/shared_ui/resource_display/fuel_display.tscn" id="3_n5xb3"]
+[ext_resource type="PackedScene" path="res://src/shared_ui/resource_display/fuel_display.tscn" id="3_n5xb3"]
 [ext_resource type="PackedScene" uid="uid://cib1fq003l5jx" path="res://src/indoor_preparation/screen_displays/shared/screen_notification.tscn" id="3_rl23t"]
 [ext_resource type="PackedScene" uid="uid://cf5qy6u2j3hhw" path="res://assets/themes/fuel_display_mini.tscn" id="5_3m24g"]
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/crew_selector/crew_member_selector.gd" id="5_vpr4d"]
@@ -17,9 +17,9 @@
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/reroll_button.gd" id="7_xg4o8"]
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/total_power_display.gd" id="9_cb4ss"]
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/barrier_preview.gd" id="9_iui7q"]
-[ext_resource type="PackedScene" uid="uid://6tyicfyiq5gf" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/character_info_panel.tscn" id="16_oou66"]
+[ext_resource type="PackedScene" uid="uid://vnu6f53bf3ur" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/character_info_panel.tscn" id="16_oou66"]
 [ext_resource type="PackedScene" uid="uid://cnphrbnb2wrnf" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/combat_results_summary.tscn" id="18_lgpuc"]
-[ext_resource type="PackedScene" uid="uid://b5yq7dbetb72t" path="res://src/shared_ui/resource_display/applicants_display.tscn" id="18_pekm7"]
+[ext_resource type="PackedScene" path="res://src/shared_ui/resource_display/applicants_display.tscn" id="18_pekm7"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_8a5xg"]
 content_margin_left = 5.0
@@ -268,7 +268,7 @@ theme_override_constants/margin_bottom = 5
 [node name="CombatMathCalculationsHud" parent="BottomInfoDisplay/Center/CrewStatus/StatusSections/CalculationsDisplay" instance=ExtResource("6_30blh")]
 layout_mode = 2
 
-[node name="TotalPowerDisplay" type="MarginContainer" parent="BottomInfoDisplay/Center/CrewStatus/StatusSections"]
+[node name="TotalPowerDisplay" type="MarginContainer" parent="BottomInfoDisplay/Center/CrewStatus/StatusSections" node_paths=PackedStringArray("total_value_label")]
 clip_contents = true
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
@@ -278,6 +278,7 @@ theme_override_constants/margin_top = 5
 theme_override_constants/margin_right = 5
 theme_override_constants/margin_bottom = 5
 script = ExtResource("9_cb4ss")
+total_value_label = NodePath("PanelContainer/VBoxContainer/TotalValue")
 
 [node name="PanelContainer" type="PanelContainer" parent="BottomInfoDisplay/Center/CrewStatus/StatusSections/TotalPowerDisplay"]
 layout_mode = 2

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_actions_display.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_actions_display.gd
@@ -1,14 +1,18 @@
-class_name CrewActionsDisplay extends MarginContainer
+class_name CrewActionsDisplay extends Control
 
 signal dice_visually_rolling_start()
 signal dice_visually_rolling_stop()
 
 @onready var database: Database = $"/root/Database"
-@onready var action_displays: Array[Node] = $PC/GC.get_children()
+var action_displays: Array[Node]
 
 func _ready() -> void:
+    action_displays = _get_child_action_displays()
     refresh()
     database.die_slots_set.connect(refresh)
+
+func _get_child_action_displays() -> Array[Node]:
+    return $PC/GC.get_children()
 
 func refresh(was_reroll: bool = false):
     var die_slots: Array[CharacterDieSlot] = database.current_character_die_slots

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_actions_display.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/crew_actions_display.gd
@@ -35,6 +35,16 @@ func _on_character_selected(selected_character: Character, button_end_state: boo
         else:
             action_display.button.button_pressed = false
 
+func _on_character_hovered(selected_character: Character, is_hovered: bool):
+    for action_display in action_displays:
+        if (action_display.character_die_slot != null
+                and action_display.character_die_slot.character == selected_character
+                ):
+            if is_hovered:
+                action_display.modulate = Color.WHITE
+            else:
+                action_display.modulate = Color.YELLOW
+
 func start_preview_reroll() -> void:
     var any_unfrozen: bool = false
     for action_display in action_displays:

--- a/game/src/battlefield_outdoors/battlefield_outdoors_hud/total_power_display.gd
+++ b/game/src/battlefield_outdoors/battlefield_outdoors_hud/total_power_display.gd
@@ -1,7 +1,7 @@
 class_name TotalPowerDisplay extends MarginContainer
 
 @onready var combat_math_formulas: CombatMathFormulas = CombatMathFormulas.new()
-@onready var total_value_label: Label = $PanelContainer/VBoxContainer/TotalValue
+@export var total_value_label: Label
 
 func _ready() -> void:
     Database.barrier_changed.connect(_on_barrier_changed)

--- a/game/src/indoor_preparation/crew_buttons/crew_button.gd
+++ b/game/src/indoor_preparation/crew_buttons/crew_button.gd
@@ -1,6 +1,8 @@
 class_name CrewButton extends TextureButton
 
 signal crew_member_selected(character: Character)
+signal crew_member_hover_changed(character: Character, is_hovered: bool)
+signal crew_member_deselected()
 
 const FADE_IN_DURATION: float = 1
 
@@ -17,6 +19,8 @@ var fade_in_tween: Tween
 
 func _ready() -> void:
     visibility_changed.connect(_on_visibility_changed)
+    mouse_entered.connect(_on_button_hovered)
+    mouse_exited.connect(_on_button_hovered)
     visible = false
     focus_mode = FocusMode.FOCUS_NONE
     _on_initial_setup(database.hired_characters)
@@ -38,6 +42,8 @@ func _on_new_character_hired(character: Character) -> void:
 func _toggled(toggled_on: bool) -> void:
     if toggled_on:
         crew_member_selected.emit(instantiated_character)
+    if not toggled_on:
+        crew_member_deselected.emit()
 
 func _on_view_canceled() -> void:
     button_pressed = false
@@ -57,3 +63,6 @@ func mimic_hover_changed(mimic_hovered: bool):
         texture_normal = original_texture_normal
     else:
         texture_normal = original_texture_hovered
+
+func _on_button_hovered() -> void:
+    crew_member_hover_changed.emit(instantiated_character, is_hovered())

--- a/game/src/indoor_preparation/crew_buttons/crew_button.gd
+++ b/game/src/indoor_preparation/crew_buttons/crew_button.gd
@@ -8,6 +8,9 @@ const FADE_IN_DURATION: float = 1
 
 @onready var database: Database = $"/root/Database"
 
+@onready var original_texture_hovered: Texture2D = texture_hover
+@onready var original_texture_normal: Texture2D = texture_normal
+
 var character_hired: bool = false
 var instantiated_character: Character
 var fade_in_tween: Tween
@@ -48,3 +51,9 @@ func _on_visibility_changed():
         fade_in_tween.set_ease(Tween.EASE_OUT)
         fade_in_tween.set_trans(Tween.TRANS_CUBIC)
         fade_in_tween.tween_property(self, "self_modulate", Color.WHITE, FADE_IN_DURATION)
+
+func mimic_hover_changed(mimic_hovered: bool):
+    if mimic_hovered:
+        texture_normal = original_texture_normal
+    else:
+        texture_normal = original_texture_hovered

--- a/game/src/indoor_preparation/crew_buttons/crew_button.tscn
+++ b/game/src/indoor_preparation/crew_buttons/crew_button.tscn
@@ -25,7 +25,6 @@ button_group = ExtResource("1_jddrr")
 texture_normal = ExtResource("1_0is4p")
 texture_pressed = ExtResource("2_bm1w8")
 texture_hover = ExtResource("3_114bo")
-texture_focused = ExtResource("2_bm1w8")
 texture_click_mask = ExtResource("4_4dfub")
 script = ExtResource("5_06drq")
 

--- a/game/src/indoor_preparation/crew_buttons/crew_buttons.tres
+++ b/game/src/indoor_preparation/crew_buttons/crew_buttons.tres
@@ -2,3 +2,4 @@
 
 [resource]
 resource_local_to_scene = false
+allow_unpress = true

--- a/game/src/indoor_preparation/crew_buttons_parent.gd
+++ b/game/src/indoor_preparation/crew_buttons_parent.gd
@@ -1,0 +1,13 @@
+class_name CrewButtonsParent extends Control
+
+@onready var crew_buttons: Array[Node] = get_children()
+
+func _on_character_hover_changed(character: Character, is_hovered: bool) -> void:
+    for crew_button in crew_buttons:
+        if crew_button.instantiated_character == character:
+            crew_button.mimic_hover_changed(is_hovered)
+
+func _on_character_selected(character: Character, end_button_state: bool) -> void:
+    for crew_button in crew_buttons:
+        if crew_button.instantiated_character == character:
+            crew_button.button_pressed = end_button_state

--- a/game/src/indoor_preparation/indoor_preparation.gd
+++ b/game/src/indoor_preparation/indoor_preparation.gd
@@ -25,10 +25,12 @@ func _ready() -> void:
         
     for crew_button in crew_buttons:
         crew_button.crew_member_selected.connect(screen._on_crew_member_selected)
+        crew_button.crew_member_deselected.connect(screen.return_to_home_display)
+        crew_button.crew_member_hover_changed.connect(
+            screen.home_display.home_actions_display._on_character_hovered)
         screen.left_character_detail_display.connect(crew_button._on_view_canceled)
         hiring_success.connect(crew_button._on_new_character_hired)
         # tell the character_action_display owner when a character is hovered so it can update display appropriately
-        # don't need to do actions because screen changes anyway.
     screen.hire_detail_display.hire_purchase_pressed.connect(_on_hire_purchase_attempted)
     screen.character_detail_display.upgrade_purchase_pressed.connect(_on_upgrade_purchase_attempted)
     hiring_success.connect(screen._on_hiring_success)

--- a/game/src/indoor_preparation/indoor_preparation.gd
+++ b/game/src/indoor_preparation/indoor_preparation.gd
@@ -10,16 +10,25 @@ const PURCHASE_FAIL_POOR_REASON: String = "INSUFFICIENT_FUNDS"
 
 @onready var database: Database = $"/root/Database"
 @onready var screen: Screen = $Screen
+@onready var crew_buttons_parent: CrewButtonsParent = $CrewButtons
 @onready var crew_buttons: Array[Node] = $CrewButtons.get_children()
 @onready var money_display: MoneyDisplay = $VBoxContainer/MoneyDisplay
 
 var applicants: Array[Character] = []
 
 func _ready() -> void:
+    for character_action_display in screen.home_display.home_actions_display.action_displays:
+        character_action_display.character_hover_changed.connect(
+            crew_buttons_parent._on_character_hover_changed)
+        character_action_display.character_selected.connect(
+            crew_buttons_parent._on_character_selected)
+        
     for crew_button in crew_buttons:
         crew_button.crew_member_selected.connect(screen._on_crew_member_selected)
         screen.left_character_detail_display.connect(crew_button._on_view_canceled)
         hiring_success.connect(crew_button._on_new_character_hired)
+        # tell the character_action_display owner when a character is hovered so it can update display appropriately
+        # don't need to do actions because screen changes anyway.
     screen.hire_detail_display.hire_purchase_pressed.connect(_on_hire_purchase_attempted)
     screen.character_detail_display.upgrade_purchase_pressed.connect(_on_upgrade_purchase_attempted)
     hiring_success.connect(screen._on_hiring_success)

--- a/game/src/indoor_preparation/indoor_preparation.tscn
+++ b/game/src/indoor_preparation/indoor_preparation.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=28 format=3 uid="uid://b73yb04wjxq8"]
+[gd_scene load_steps=29 format=3 uid="uid://b73yb04wjxq8"]
 
 [ext_resource type="Texture2D" uid="uid://l3l2yqfmprg5" path="res://assets/art/ld_56_indoors.jpg" id="1_f348j"]
 [ext_resource type="Script" path="res://src/indoor_preparation/indoor_preparation.gd" id="2_0rynj"]
@@ -17,6 +17,7 @@
 [ext_resource type="Resource" uid="uid://duswkektwj6hb" path="res://assets/data/characters/002_lizard_char.tres" id="10_lfrlp"]
 [ext_resource type="Resource" uid="uid://b3l83j0ql7m0e" path="res://assets/data/characters/003_test_pal.tres" id="12_tfexc"]
 [ext_resource type="Resource" uid="uid://bfkdaseurpvu6" path="res://assets/data/characters/004_test_pal.tres" id="13_1osln"]
+[ext_resource type="Script" path="res://src/indoor_preparation/crew_buttons_parent.gd" id="13_2a042"]
 [ext_resource type="Resource" uid="uid://dexsvne2ukrlr" path="res://assets/data/characters/005_test_pal.tres" id="14_kx6ve"]
 [ext_resource type="Resource" uid="uid://bawjwhqx6mbin" path="res://assets/data/characters/006_test_pal.tres" id="15_nfr47"]
 [ext_resource type="Resource" uid="uid://h8yglehg8si2" path="res://assets/data/characters/007_test_pal.tres" id="16_pnxxu"]
@@ -92,6 +93,7 @@ layout_mode = 1
 
 [node name="CrewButtons" type="Control" parent="."]
 anchors_preset = 0
+script = ExtResource("13_2a042")
 
 [node name="CrewButton" parent="CrewButtons" instance=ExtResource("8_40muy")]
 layout_mode = 0

--- a/game/src/indoor_preparation/indoor_preparation.tscn
+++ b/game/src/indoor_preparation/indoor_preparation.tscn
@@ -26,7 +26,7 @@
 [ext_resource type="Resource" uid="uid://1nhgxq12mwuo" path="res://assets/data/characters/011_test_pal.tres" id="20_pbwmt"]
 [ext_resource type="Resource" uid="uid://beppcdvy1b3s0" path="res://assets/data/characters/012_test_pal.tres" id="21_71v0u"]
 [ext_resource type="PackedScene" uid="uid://cnbbp4gy833n" path="res://src/shared_ui/resource_display/money_display.tscn" id="25_dg1g1"]
-[ext_resource type="PackedScene" uid="uid://cjb6144n5q1b1" path="res://src/shared_ui/resource_display/fuel_display.tscn" id="26_fgbkb"]
+[ext_resource type="PackedScene" path="res://src/shared_ui/resource_display/fuel_display.tscn" id="26_fgbkb"]
 
 [node name="IndoorPreparation" type="Control"]
 layout_mode = 3
@@ -59,7 +59,6 @@ theme = ExtResource("4_u741y")
 script = ExtResource("3_culvi")
 
 [node name="HomeDisplay" parent="Screen" instance=ExtResource("3_eot0a")]
-visible = false
 layout_mode = 1
 
 [node name="HirePreviewDisplay" parent="Screen" instance=ExtResource("4_note4")]
@@ -71,6 +70,7 @@ visible = false
 layout_mode = 1
 
 [node name="CharacterDetail" parent="Screen" instance=ExtResource("6_4pq4g")]
+visible = false
 layout_mode = 1
 
 [node name="NotificationDimmer" type="ColorRect" parent="Screen"]

--- a/game/src/indoor_preparation/screen.gd
+++ b/game/src/indoor_preparation/screen.gd
@@ -99,6 +99,8 @@ func _on_cancel() -> void:
                 _delay_callback(home_display.show)
 
 func _on_hiring_success(character: Character) -> void:
+    home_display.refresh_crew_info()
+
     notification_dimmer.show()
     screen_notification.display_notification(
         ScreenNotification.ScreenNotificationType.NOTIFY,

--- a/game/src/indoor_preparation/screen_displays/home_actions_display.gd
+++ b/game/src/indoor_preparation/screen_displays/home_actions_display.gd
@@ -1,0 +1,7 @@
+class_name HomeActionsDisplay extends CrewActionsDisplay
+
+func _get_child_action_displays() -> Array[Node]:
+    var result: Array[Node] = []
+    result.append_array($ActionsRow1.get_children())
+    result.append_array($ActionsRow2.get_children())
+    return result

--- a/game/src/indoor_preparation/screen_displays/home_display.gd
+++ b/game/src/indoor_preparation/screen_displays/home_display.gd
@@ -7,12 +7,17 @@ signal view_applicants_button_pressed()
 @onready var barrier_portrait: TextureRect = $MainContents/BarrierDetails/Image
 @onready var weakness_icon: TextureRect = $MainContents/BarrierDetails/StatsContainer/WeaknessContainer/MarginContainer/HBoxContainer/WeaknessIcon
 @onready var power_value: Label = $MainContents/BarrierDetails/StatsContainer/PowerContainer/MarginContainer/HBoxContainer2/PowerValue
-@onready var flavor_text: Label = $MainContents/MarginContainer/FlavorText
 @onready var view_applicants_button: Button = $MarginContainer/Button
+@onready var home_actions_display: HomeActionsDisplay = $MainContents/PanelContainer/MarginContainer/HBoxContainer/HomeActionsDisplay
+@onready var total_power_display: TotalPowerDisplay = $MainContents/PanelContainer/MarginContainer/HBoxContainer/PanelContainer/TotalPowerDisplay
 
 func _ready() -> void:
     view_applicants_button.pressed.connect(_propagate_applicants_button_pressed)
 
+func refresh_crew_info():
+    home_actions_display.refresh()
+    total_power_display.refresh()
+    
 func set_barrier(barrier_data: BarrierData):
     if barrier_data != null:
         barrier_name.text = barrier_data.name

--- a/game/src/indoor_preparation/screen_displays/home_display.gd
+++ b/game/src/indoor_preparation/screen_displays/home_display.gd
@@ -13,6 +13,7 @@ signal view_applicants_button_pressed()
 
 func _ready() -> void:
     view_applicants_button.pressed.connect(_propagate_applicants_button_pressed)
+    visibility_changed.connect(_on_visibility_changed)
 
 func refresh_crew_info():
     home_actions_display.refresh()
@@ -30,3 +31,9 @@ func set_barrier(barrier_data: BarrierData):
 
 func _propagate_applicants_button_pressed():
     view_applicants_button_pressed.emit()
+
+func _on_visibility_changed():
+    if visible:
+        home_actions_display.enable_all()
+    else:
+        home_actions_display.disable_all()

--- a/game/src/indoor_preparation/screen_displays/home_display.tscn
+++ b/game/src/indoor_preparation/screen_displays/home_display.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=8 format=3 uid="uid://7vx27hr83tx0"]
+[gd_scene load_steps=9 format=3 uid="uid://7vx27hr83tx0"]
 
 [ext_resource type="Script" path="res://src/indoor_preparation/screen_displays/home_display.gd" id="1_b3nrn"]
 [ext_resource type="Theme" uid="uid://dmwrgmv8lathf" path="res://assets/themes/ScreenTheme.tres" id="1_d2gyf"]
 [ext_resource type="PackedScene" uid="uid://h1fowbxngb70" path="res://src/audio_manager/AudioManager.tscn" id="3_2jj1q"]
 [ext_resource type="Texture2D" uid="uid://bic3i142epdt3" path="res://assets/art/placeholder_threat.png" id="3_4hdf6"]
 [ext_resource type="Texture2D" uid="uid://cmdqbv4iraqg6" path="res://assets/art/MAGIC_icon_64x64.png" id="4_o5aea"]
+[ext_resource type="Script" path="res://src/indoor_preparation/screen_displays/home_actions_display.gd" id="6_n44i5"]
 [ext_resource type="PackedScene" uid="uid://dr7v1vu064ukv" path="res://src/shared_ui/character_action_display/character_action_display.tscn" id="6_ymb1a"]
 [ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/total_power_display.gd" id="7_u3vh7"]
 
@@ -119,72 +120,75 @@ theme_override_constants/margin_right = 5
 theme_override_constants/margin_bottom = 5
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MainContents/PanelContainer/MarginContainer"]
-custom_minimum_size = Vector2(0, 105)
+custom_minimum_size = Vector2(374, 105)
 layout_mode = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer"]
+[node name="HomeActionsDisplay" type="VBoxContainer" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer"]
 layout_mode = 2
+size_flags_horizontal = 6
+script = ExtResource("6_n44i5")
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 4
-theme_override_constants/separation = 5
-
-[node name="CharacterActionDisplay" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer" instance=ExtResource("6_ymb1a")]
-custom_minimum_size = Vector2(50, 50)
-layout_mode = 2
-size_flags_horizontal = 4
-
-[node name="CharacterActionDisplay2" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer" instance=ExtResource("6_ymb1a")]
-custom_minimum_size = Vector2(50, 50)
-layout_mode = 2
-size_flags_horizontal = 4
-
-[node name="CharacterActionDisplay3" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer" instance=ExtResource("6_ymb1a")]
-custom_minimum_size = Vector2(50, 50)
-layout_mode = 2
-size_flags_horizontal = 4
-
-[node name="CharacterActionDisplay4" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer" instance=ExtResource("6_ymb1a")]
-custom_minimum_size = Vector2(50, 50)
-layout_mode = 2
-size_flags_horizontal = 4
-
-[node name="HBoxContainer3" type="HBoxContainer" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer"]
+[node name="ActionsRow1" type="HBoxContainer" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/HomeActionsDisplay"]
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_constants/separation = 5
 
-[node name="CharacterActionDisplay5" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer3" instance=ExtResource("6_ymb1a")]
+[node name="CharacterActionDisplay" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/HomeActionsDisplay/ActionsRow1" instance=ExtResource("6_ymb1a")]
 custom_minimum_size = Vector2(50, 50)
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="CharacterActionDisplay6" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer3" instance=ExtResource("6_ymb1a")]
+[node name="CharacterActionDisplay2" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/HomeActionsDisplay/ActionsRow1" instance=ExtResource("6_ymb1a")]
 custom_minimum_size = Vector2(50, 50)
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="CharacterActionDisplay7" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer3" instance=ExtResource("6_ymb1a")]
+[node name="CharacterActionDisplay3" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/HomeActionsDisplay/ActionsRow1" instance=ExtResource("6_ymb1a")]
 custom_minimum_size = Vector2(50, 50)
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="CharacterActionDisplay8" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer3" instance=ExtResource("6_ymb1a")]
+[node name="CharacterActionDisplay4" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/HomeActionsDisplay/ActionsRow1" instance=ExtResource("6_ymb1a")]
 custom_minimum_size = Vector2(50, 50)
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="CharacterActionDisplay9" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer3" instance=ExtResource("6_ymb1a")]
+[node name="ActionsRow2" type="HBoxContainer" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/HomeActionsDisplay"]
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_constants/separation = 5
+
+[node name="CharacterActionDisplay5" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/HomeActionsDisplay/ActionsRow2" instance=ExtResource("6_ymb1a")]
+custom_minimum_size = Vector2(50, 50)
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="CharacterActionDisplay6" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/HomeActionsDisplay/ActionsRow2" instance=ExtResource("6_ymb1a")]
+custom_minimum_size = Vector2(50, 50)
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="CharacterActionDisplay7" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/HomeActionsDisplay/ActionsRow2" instance=ExtResource("6_ymb1a")]
+custom_minimum_size = Vector2(50, 50)
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="CharacterActionDisplay8" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/HomeActionsDisplay/ActionsRow2" instance=ExtResource("6_ymb1a")]
+custom_minimum_size = Vector2(50, 50)
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="CharacterActionDisplay9" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/HomeActionsDisplay/ActionsRow2" instance=ExtResource("6_ymb1a")]
 custom_minimum_size = Vector2(50, 50)
 layout_mode = 2
 size_flags_horizontal = 4
 
 [node name="PanelContainer" type="PanelContainer" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer"]
 layout_mode = 2
+size_flags_horizontal = 8
 size_flags_vertical = 4
 
-[node name="TotalPowerDisplay" type="MarginContainer" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/PanelContainer"]
+[node name="TotalPowerDisplay" type="MarginContainer" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/PanelContainer" node_paths=PackedStringArray("total_value_label")]
 clip_contents = true
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
@@ -192,6 +196,7 @@ size_flags_horizontal = 8
 theme_override_constants/margin_top = 5
 theme_override_constants/margin_right = 5
 script = ExtResource("7_u3vh7")
+total_value_label = NodePath("VBoxContainer/TotalValue")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/PanelContainer/TotalPowerDisplay"]
 layout_mode = 2

--- a/game/src/indoor_preparation/screen_displays/home_display.tscn
+++ b/game/src/indoor_preparation/screen_displays/home_display.tscn
@@ -1,10 +1,12 @@
-[gd_scene load_steps=6 format=3 uid="uid://7vx27hr83tx0"]
+[gd_scene load_steps=8 format=3 uid="uid://7vx27hr83tx0"]
 
 [ext_resource type="Script" path="res://src/indoor_preparation/screen_displays/home_display.gd" id="1_b3nrn"]
 [ext_resource type="Theme" uid="uid://dmwrgmv8lathf" path="res://assets/themes/ScreenTheme.tres" id="1_d2gyf"]
 [ext_resource type="PackedScene" uid="uid://h1fowbxngb70" path="res://src/audio_manager/AudioManager.tscn" id="3_2jj1q"]
 [ext_resource type="Texture2D" uid="uid://bic3i142epdt3" path="res://assets/art/placeholder_threat.png" id="3_4hdf6"]
 [ext_resource type="Texture2D" uid="uid://cmdqbv4iraqg6" path="res://assets/art/MAGIC_icon_64x64.png" id="4_o5aea"]
+[ext_resource type="PackedScene" uid="uid://dr7v1vu064ukv" path="res://src/shared_ui/character_action_display/character_action_display.tscn" id="6_ymb1a"]
+[ext_resource type="Script" path="res://src/battlefield_outdoors/battlefield_outdoors_hud/total_power_display.gd" id="7_u3vh7"]
 
 [node name="HomeDisplay" type="Control"]
 layout_mode = 3
@@ -32,7 +34,7 @@ grow_horizontal = 2
 layout_mode = 2
 theme = ExtResource("1_d2gyf")
 theme_override_font_sizes/font_size = 24
-text = "NEXT THREAT"
+text = "CURRENT THREAT"
 horizontal_alignment = 1
 
 [node name="BarrierName" type="Label" parent="MainContents"]
@@ -106,15 +108,108 @@ theme_override_font_sizes/font_size = 32
 text = "50"
 horizontal_alignment = 1
 
-[node name="MarginContainer" type="MarginContainer" parent="MainContents"]
+[node name="PanelContainer" type="PanelContainer" parent="MainContents"]
 layout_mode = 2
-theme_override_constants/margin_top = 20
 
-[node name="FlavorText" type="Label" parent="MainContents/MarginContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="MainContents/PanelContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MainContents/PanelContainer/MarginContainer"]
+custom_minimum_size = Vector2(0, 105)
+layout_mode = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer"]
+layout_mode = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 4
-text = "\"A Dangerous Foe\""
+theme_override_constants/separation = 5
+
+[node name="CharacterActionDisplay" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer" instance=ExtResource("6_ymb1a")]
+custom_minimum_size = Vector2(50, 50)
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="CharacterActionDisplay2" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer" instance=ExtResource("6_ymb1a")]
+custom_minimum_size = Vector2(50, 50)
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="CharacterActionDisplay3" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer" instance=ExtResource("6_ymb1a")]
+custom_minimum_size = Vector2(50, 50)
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="CharacterActionDisplay4" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer" instance=ExtResource("6_ymb1a")]
+custom_minimum_size = Vector2(50, 50)
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_constants/separation = 5
+
+[node name="CharacterActionDisplay5" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer3" instance=ExtResource("6_ymb1a")]
+custom_minimum_size = Vector2(50, 50)
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="CharacterActionDisplay6" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer3" instance=ExtResource("6_ymb1a")]
+custom_minimum_size = Vector2(50, 50)
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="CharacterActionDisplay7" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer3" instance=ExtResource("6_ymb1a")]
+custom_minimum_size = Vector2(50, 50)
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="CharacterActionDisplay8" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer3" instance=ExtResource("6_ymb1a")]
+custom_minimum_size = Vector2(50, 50)
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="CharacterActionDisplay9" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer3" instance=ExtResource("6_ymb1a")]
+custom_minimum_size = Vector2(50, 50)
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="PanelContainer" type="PanelContainer" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 4
+
+[node name="TotalPowerDisplay" type="MarginContainer" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/PanelContainer"]
+clip_contents = true
+custom_minimum_size = Vector2(100, 0)
+layout_mode = 2
+size_flags_horizontal = 8
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+script = ExtResource("7_u3vh7")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/PanelContainer/TotalPowerDisplay"]
+layout_mode = 2
+size_flags_vertical = 4
+
+[node name="TotalHeader" type="Label" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/PanelContainer/TotalPowerDisplay/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 0
+text = "Crew:"
 horizontal_alignment = 1
+
+[node name="TotalValue" type="Label" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/PanelContainer/TotalPowerDisplay/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 8
+theme_override_font_sizes/font_size = 48
+text = "100"
+horizontal_alignment = 1
+vertical_alignment = 1
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 custom_minimum_size = Vector2(0, 50)

--- a/game/src/indoor_preparation/screen_displays/home_display.tscn
+++ b/game/src/indoor_preparation/screen_displays/home_display.tscn
@@ -194,13 +194,11 @@ custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 size_flags_horizontal = 8
 theme_override_constants/margin_top = 5
-theme_override_constants/margin_right = 5
 script = ExtResource("7_u3vh7")
 total_value_label = NodePath("VBoxContainer/TotalValue")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/PanelContainer/TotalPowerDisplay"]
 layout_mode = 2
-size_flags_vertical = 4
 
 [node name="TotalHeader" type="Label" parent="MainContents/PanelContainer/MarginContainer/HBoxContainer/PanelContainer/TotalPowerDisplay/VBoxContainer"]
 layout_mode = 2

--- a/game/src/shared_ui/character_action_display/character_action_display.gd
+++ b/game/src/shared_ui/character_action_display/character_action_display.gd
@@ -1,6 +1,7 @@
 class_name CharacterActionDisplay extends TextureRect
 
 signal character_selected(character: Character, button_end_state: bool)
+signal character_hover_changed(character: Character, is_hovered: bool)
 
 @onready var die_result: DieResult = $DieResult
 @onready var frozen_background: Control = $FrozenBackground
@@ -16,6 +17,8 @@ var rolling_tween: Tween
 func _ready() -> void:
     button.gui_input.connect(_handle_freeze_roll_action)
     button.pressed.connect(_on_button_pressed)
+    button.mouse_entered.connect(_on_button_hovered)
+    button.mouse_exited.connect(_on_button_hovered)
     Database.die_slot_changed.connect(_on_die_slot_update)
 
 func refresh(trigger_particles: bool = false) -> void:
@@ -52,6 +55,9 @@ func _handle_freeze_roll_action(event: InputEvent):
 
 func _on_button_pressed() -> void:
     character_selected.emit(character_die_slot.character, button.button_pressed)
+
+func _on_button_hovered() -> void:
+    character_hover_changed.emit(character_die_slot.character, button.is_hovered())
 
 func _on_die_slot_update(changed_die_slot: CharacterDieSlot) -> void:
     if changed_die_slot == character_die_slot:


### PR DESCRIPTION
Add power information & character die rolls to the home screen:
![image](https://github.com/user-attachments/assets/70464e7a-fb72-4363-9c29-839801e6b56c)

helps relate the cool pictures of characters to the stats we've been looking at. 

Incidentally also allows locking and unlocking dice inside the inside view, which is interesting.

Good stuff all around.