### PR TITLE
Database - Add Field to Set an Initial Number of Crew Applicants

### DIFF
--- a/game/assets/data/database.gd
+++ b/game/assets/data/database.gd
@@ -43,11 +43,12 @@ const _initial_barriers_cost_to_overcome_number: int = 0
 const _initial_first_hiring_round: int = 3
 const _initial_reroll_fuel_cost = 1
 const _initial_character_die_slots: Array[CharacterDieSlot] = []
+# Hardcoded maximum limit of 4 applicants at a time to fit the UI and logic.
+const _initial_initial_applicant_count: int = 0
 const _initial_money: int = 0
 const _initial_fuel: int = 2
 const _initial_matching_stat_type_multiplier: int = 2
 const _initial_war_transport_health_maximum: int = 10
-const _initial_applicant_count = 0
 
 const _maximum_fuel: int = 10
 
@@ -83,6 +84,7 @@ var current_reroll_fuel_cost: int
 var current_character_die_slots: Array[CharacterDieSlot]
 var current_matching_stat_type_multiplier: int
 var first_hiring_round: int
+var initial_applicant_count: int
 var war_transport_health_current: int
 var war_transport_health_maximum: int
 
@@ -160,6 +162,7 @@ func reset_values() -> void:
     set_current_matching_stat_type_multiplier(
         _initial_matching_stat_type_multiplier
     )
+    set_initial_applicant_count(_initial_initial_applicant_count)
     set_war_transport_health_maximum(_initial_war_transport_health_maximum)
     set_money(_initial_money)
     set_fuel(_initial_fuel)
@@ -277,6 +280,9 @@ func set_current_matching_stat_type_multiplier(updated_number: int) -> void:
 
 func set_first_hiring_round(updated_number: int) -> void:
     first_hiring_round = updated_number
+
+func set_initial_applicant_count(updated_number: int) -> void:
+    initial_applicant_count = updated_number
 
 func set_war_transport_health_current(updated_health: int) -> void:
     var old_health = war_transport_health_current

--- a/game/assets/data/database.gd
+++ b/game/assets/data/database.gd
@@ -47,6 +47,7 @@ const _initial_money: int = 0
 const _initial_fuel: int = 2
 const _initial_matching_stat_type_multiplier: int = 2
 const _initial_war_transport_health_maximum: int = 10
+const _initial_applicant_count = 0
 
 const _maximum_fuel: int = 10
 

--- a/game/assets/data/database.gd
+++ b/game/assets/data/database.gd
@@ -40,6 +40,7 @@ const _initial_barriers_linear_scale_amount: int = 1
 const _initial_barriers_stat_type_to_overcome: StatType = StatType.MIGHT
 const _initial_barriers_overcome_count: int = 0
 const _initial_barriers_cost_to_overcome_number: int = 0
+const _initial_first_hiring_round: int = 3
 const _initial_reroll_fuel_cost = 1
 const _initial_character_die_slots: Array[CharacterDieSlot] = []
 const _initial_money: int = 0
@@ -80,6 +81,7 @@ var current_barrier_data: BarrierData
 var current_reroll_fuel_cost: int
 var current_character_die_slots: Array[CharacterDieSlot]
 var current_matching_stat_type_multiplier: int
+var first_hiring_round: int
 var war_transport_health_current: int
 var war_transport_health_maximum: int
 
@@ -145,6 +147,9 @@ func reset_values() -> void:
     set_barriers_linear_scale_amount(_initial_barriers_linear_scale_amount)
     set_current_barrier_cost_to_overcome_number(
         _initial_barriers_cost_to_overcome_number
+    )
+    set_first_hiring_round(
+        _initial_first_hiring_round
     )
     set_current_barrier_stat_type_to_overcome(
         _initial_barriers_stat_type_to_overcome
@@ -268,6 +273,9 @@ func set_current_character_die_slots(
 
 func set_current_matching_stat_type_multiplier(updated_number: int) -> void:
     current_matching_stat_type_multiplier = updated_number
+
+func set_first_hiring_round(updated_number: int) -> void:
+    first_hiring_round = updated_number
 
 func set_war_transport_health_current(updated_health: int) -> void:
     var old_health = war_transport_health_current

--- a/game/src/hiring/applicant_orchestrator.gd
+++ b/game/src/hiring/applicant_orchestrator.gd
@@ -11,8 +11,8 @@ var rounds_since_applicant_left: int = 0
 func _ready() -> void:
     rounds_since_last_applicant = 10 - min(4, Database.barriers_overcome_count)
 
-    if Database._initial_applicant_count > 0 and Database.applicants.is_empty():
-        Database.set_current_applicants(_select_new_applicants(Database._initial_applicant_count))
+    if Database.initial_applicant_count > 0 and Database.applicants.is_empty():
+        Database.set_current_applicants(_select_new_applicants(Database.initial_applicant_count))
 
 func update_applicants():
     var current_round: int = Database.barriers_overcome_count

--- a/game/src/hiring/applicant_orchestrator.gd
+++ b/game/src/hiring/applicant_orchestrator.gd
@@ -5,7 +5,6 @@ signal new_applicants_arrived()
 const NEW_APPLICANTS_MESSAGE: String = "Mercenaries are looking for work.\nCurrent number of applicants: %s"
 const NEW_APPLICANTS_DURATION: float = 3.0
 
-var first_hiring_round: int = 3
 var rounds_since_last_applicant: int = 0
 var rounds_since_applicant_left: int = 0
 
@@ -17,7 +16,7 @@ func update_applicants():
     var current_applicants: Array[Character] = Database.applicants
     var crew_size: int = Database.hired_character_count
 
-    if current_round < first_hiring_round:
+    if current_round < Database.first_hiring_round:
         return
     
     rounds_since_applicant_left += 1

--- a/game/src/hiring/applicant_orchestrator.gd
+++ b/game/src/hiring/applicant_orchestrator.gd
@@ -11,6 +11,9 @@ var rounds_since_applicant_left: int = 0
 func _ready() -> void:
     rounds_since_last_applicant = 10 - min(4, Database.barriers_overcome_count)
 
+    if Database._initial_applicant_count > 0 and Database.applicants.is_empty():
+        Database.set_current_applicants(_select_new_applicants(Database._initial_applicant_count))
+
 func update_applicants():
     var current_round: int = Database.barriers_overcome_count
     var current_applicants: Array[Character] = Database.applicants


### PR DESCRIPTION
Make it easier to test the indoors when starting applicants may be coded as a number higher than 0 via new database constant `_initial_initial_applicant_count`.

## Implementation Details

Include a setter and public version of the property for standardized access.