### PR TITLE
SFX - Setup Character Custom SFX to Populate from Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A game created for Ludum Dare 56 - a family affair.
 
 Team members include:
 
-- Noah Bumgardner: Programming & Music
+- Luke Bumgardner: Voice Actor
+- Noah Bumgardner: Music, Programming, Voice Actor
 - Sam Bumgardner: Programming
 - Tom Bumgardner: Artwork
 

--- a/game/assets/data/scenarios/easy_scenario.tres
+++ b/game/assets/data/scenarios/easy_scenario.tres
@@ -29,11 +29,15 @@ current_fuel = 5
 [sub_resource type="Resource" id="Resource_ms3ae"]
 script = ExtResource("15_1r0vp")
 starts_at = 0
+arrival_bonus_heal = 0
+arrival_bonus_barrier_reduction = 0
 region = ExtResource("12_fgyj2")
 
 [sub_resource type="Resource" id="Resource_0unf2"]
 script = ExtResource("15_1r0vp")
 starts_at = 100
+arrival_bonus_heal = 0
+arrival_bonus_barrier_reduction = 0
 region = ExtResource("13_1v4v2")
 
 [resource]

--- a/game/src/audio_manager/audio_manager.gd
+++ b/game/src/audio_manager/audio_manager.gd
@@ -166,7 +166,6 @@ func _on_lock_button_pressed():
 func _on_new_hire_preview_button_pressed():
     SoundManager.play_ui_sound(sfx_indoors_enter_a_menu, _bus_name_sfx_ui)
 
-# Reused for 2 buttons.
 func _on_purchase_button_pressed():
     SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
 
@@ -188,17 +187,38 @@ func _on_to_main_menu_pressed():
 #endregion Button press
 
 
-#region Character select
-# Selecting a character is treated like a menu navigation SFX for simplicity.
+#region Character upgrade
 
-func _on_crew_button_crew_member_selected(_character):
-    SoundManager.play_ui_sound(sfx_indoors_enter_a_menu, _bus_name_sfx_ui)
+func _on_crew_member_detail_upgrade_purchase_pressed(
+    character: Character,
+    _upgrade_choice: UpgradeChoice,
+    _level_idx: int,
+    _choice_idx: int
+):
+    if character.sfx_upgrade_gained == null:
+        SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
+        return
+
+    SoundManager.play_ui_sound(character.sfx_upgrade_gained, _bus_name_sfx_ui)
+
+#endregion Character upgrade
+
+
+#region Character select
+
+# Include a click SFX whether or not a character specific SFX is also played.
+func _on_character_action_display_character_selected(_character, _button_end_state):
+    SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
+
+func _on_crew_button_crew_member_selected(character: Character):
+    if character.sfx_hello == null:
+        SoundManager.play_ui_sound(sfx_indoors_enter_a_menu, _bus_name_sfx_ui)
+        return
+
+    SoundManager.play_ui_sound(character.sfx_hello, _bus_name_sfx_ui)
 
 func _on_crew_selector_button_character_selected(_character, _button_end_state):
-    SoundManager.play_ui_sound(sfx_indoors_enter_a_menu, _bus_name_sfx_ui)
-
-func _on_character_action_display_character_selected(_character, _button_end_state):
-    SoundManager.play_ui_sound(sfx_indoors_enter_a_menu, _bus_name_sfx_ui)
+    SoundManager.play_ui_sound(sfx_button_click, _bus_name_sfx_ui)
 
 #endregion
 

--- a/game/src/characters/Character.gd
+++ b/game/src/characters/Character.gd
@@ -7,6 +7,8 @@ var description: String
 var portrait: Texture2D
 var icon: Texture2D
 var actions: ActionSelector
+var sfx_hello: AudioStream
+var sfx_upgrade_gained: AudioStream
 var upgrade_level: int
 var upgrades: Array[UpgradeSelector]
 var upgrade_choice_history: Array[int]
@@ -14,7 +16,8 @@ var hiring_cost: int
 
 func _init(_name: String, _description: String, _portrait: Texture2D,
         _icon: Texture2D, _actions: ActionSelector, _upgrade_level: int,
-        _upgrades: Array[UpgradeSelector], _hiring_cost: int) -> void:
+        _upgrades: Array[UpgradeSelector], _hiring_cost: int,
+        _sfx_hello: AudioStream, _sfx_upgrade_gained: AudioStream) -> void:
     name = _name
     description = _description
     portrait = _portrait
@@ -30,6 +33,8 @@ func _init(_name: String, _description: String, _portrait: Texture2D,
     for i: int in range(upgrades.size()):
         upgrade_choice_history.append(-1)
     hiring_cost = _hiring_cost
+    sfx_hello = _sfx_hello
+    sfx_upgrade_gained = _sfx_upgrade_gained
 
 func deep_copy() -> Character:
     var current_actions = actions.get_all()
@@ -39,7 +44,7 @@ func deep_copy() -> Character:
     var new_action_selector = ActionSelector.new(new_actions)
     
     var copy: Character = Character.new(name, description, portrait, icon, new_action_selector,
-        upgrade_level, upgrades, hiring_cost)
+        upgrade_level, upgrades, hiring_cost, sfx_hello, sfx_upgrade_gained)
     
     copy.upgrade_choice_history = upgrade_choice_history.duplicate()
 

--- a/game/src/characters/CharacterFactory.gd
+++ b/game/src/characters/CharacterFactory.gd
@@ -4,6 +4,8 @@ class_name CharacterFactory extends Resource
 @export_multiline var description: String
 @export var portrait: Texture2D
 @export var icon: Texture2D
+@export var sfx_hello: AudioStream
+@export var sfx_upgrade_gained: AudioStream
 @export var starting_action_strings: Array[String]
 @export var upgrade_level: int
 @export var upgrades: Array[UpgradeSelector]
@@ -19,7 +21,9 @@ func instantiate(hiring_cost: int = 10) -> Character:
         action_selector,
         upgrade_level,
         upgrades,
-        hiring_cost
+        hiring_cost,
+        sfx_hello,
+        sfx_upgrade_gained
     )
 
 func _build_starting_actions() -> Array[Action]:

--- a/game/src/indoor_preparation/screen_displays/crew_member_detail/crew_member_detail.tscn
+++ b/game/src/indoor_preparation/screen_displays/crew_member_detail/crew_member_detail.tscn
@@ -16,5 +16,6 @@ layout_mode = 2
 [node name="OptionalHeader" parent="." index="6"]
 visible = false
 
+[connection signal="upgrade_purchase_pressed" from="." to="AudioManager" method="_on_crew_member_detail_upgrade_purchase_pressed"]
 [connection signal="mouse_entered" from="ExitButton" to="AudioManager" method="_on_crew_member_detail_exit_button_mouse_entered"]
 [connection signal="pressed" from="ExitButton" to="AudioManager" method="_on_crew_member_detail_exit_button_pressed"]

--- a/game/src/indoor_preparation/screen_displays/crew_member_detail/upgrade_prompt.tscn
+++ b/game/src/indoor_preparation/screen_displays/crew_member_detail/upgrade_prompt.tscn
@@ -37,4 +37,3 @@ disabled = true
 text = "BUY"
 
 [connection signal="mouse_entered" from="MarginContainer/VBoxContainer/PurchaseButton" to="." method="_on_purchase_button_mouse_entered"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/PurchaseButton" to="AudioManager" method="_on_purchase_button_pressed"]

--- a/game/src/settings_menu/SettingsMenu.tscn
+++ b/game/src/settings_menu/SettingsMenu.tscn
@@ -76,7 +76,7 @@ text = "Back"
 
 [connection signal="ready" from="." to="AudioManager" method="_on_settings_menu_ready"]
 [connection signal="mouse_entered" from="CenterContainer/VBoxContainer/ResetToDefaultsButton" to="AudioManager" method="_on_reset_to_defaults_button_mouse_entered"]
-[connection signal="pressed" from="CenterContainer/VBoxContainer/ResetToDefaultsButton" to="." method="_on_reset_to_defaults_button_pressed"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/ResetToDefaultsButton" to="." method="_on_button_pressed"]
+[connection signal="pressed" from="CenterContainer/VBoxContainer/ResetToDefaultsButton" to="." method="_on_reset_to_defaults_button_pressed"]
 [connection signal="mouse_entered" from="CenterContainer/VBoxContainer/BackButton" to="AudioManager" method="_on_back_button_mouse_entered"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/BackButton" to="." method="_on_back_button_pressed"]

--- a/game/src/start_menu/StartMenu.tscn
+++ b/game/src/start_menu/StartMenu.tscn
@@ -3,8 +3,8 @@
 [ext_resource type="Script" path="res://src/start_menu/start_menu.gd" id="1_1710u"]
 [ext_resource type="Theme" uid="uid://duflqnf122e6l" path="res://assets/themes/StartMenu.tres" id="1_io06w"]
 [ext_resource type="PackedScene" uid="uid://h1fowbxngb70" path="res://src/audio_manager/AudioManager.tscn" id="3_kgn8u"]
-[ext_resource type="Theme" path="res://assets/themes/StartMenuButtons.tres" id="3_qd2mb"]
-[ext_resource type="Theme" path="res://assets/themes/StartMenuTitle.tres" id="4_hmxdc"]
+[ext_resource type="Theme" uid="uid://dxolpwravnfdn" path="res://assets/themes/StartMenuButtons.tres" id="3_qd2mb"]
+[ext_resource type="Theme" uid="uid://bd7imtqn8b8ak" path="res://assets/themes/StartMenuTitle.tres" id="4_hmxdc"]
 [ext_resource type="PackedScene" uid="uid://dbs7sk334clc7" path="res://src/battlefield_outdoors/battlefield_outdoors_background/BattlefieldOutdoorsBackground.tscn" id="5_1ihwe"]
 
 [node name="StartMenu" type="Control"]


### PR DESCRIPTION
Setup PR for giving unique SFX based on the character clicked or upgrade spent on.

## Implementation Details

Property `sfx_hello` is for clicking the large indoor character icons. Property `sfx_upgrade_gained` is for buying an upgrade. Also add Luke to the README.md credits since his voice will be used for upcoming sound effects.

### Known Issues

Clicking an upgrade choice or opening a notification still does not have SFXs yet.

Failing to buy an upgrade plays the character upgrade SFX, instead of add a new error SFX.

### Screenshot

![pr-87_sfx-indoors-setup](https://github.com/user-attachments/assets/4e9d7210-3414-4416-9e3c-756282a05e8f)
_**Screenshot 1:** Screenshot of the indoors upgrade screen where SFX will be heard by buying an upgrade or clicking a large character icon._