### PR TITLE
audio manager fix - remove freed players from pool

### DIFF
--- a/game/addons/sound_manager/abstract_audio_player_pool.gd
+++ b/game/addons/sound_manager/abstract_audio_player_pool.gd
@@ -76,6 +76,7 @@ func mark_player_as_available(player: AudioStreamPlayer) -> void:
         busy_players.erase(player)
 
     if available_players.size() >= default_pool_size:
+        available_players.erase(player)
         player.queue_free()
     elif not available_players.has(player):
         available_players.append(player)


### PR DESCRIPTION
This fixes a bug in AudioManager that could cause a crash during runtime.

It would only happen if our number of available players exceeded the queue size, which presumably didn't happen until we got these larger voice lines.