### PR TITLE
Allow Introduction Skip with Any Input in 2 Parts

### DIFF
--- a/game/src/start_menu/intro_sequence/intro_sequence.gd
+++ b/game/src/start_menu/intro_sequence/intro_sequence.gd
@@ -6,6 +6,11 @@ static var has_played_once: bool = false
 
 @onready var animation_player: AnimationPlayer = $AnimationPlayer
 
+const animation_time_flash_point: float = 5.5
+const animation_time_near_after_flash_point: float = 6
+const animation_time_near_end_point: float = 7.49
+
+
 func _ready():
     animation_player.play("intro_sequence")
     if not has_played_once:
@@ -14,11 +19,24 @@ func _ready():
         await get_tree().process_frame == true
         animation_player.advance(animation_player.current_animation.length())
 
+
 func _on_animation_player_animation_finished(anim_name: StringName) -> void:
     intro_finished.emit()
 
+
+# Allow skipping the introduction animation in 2 parts when anything is pressed
+#  or clicked.
 func _process(delta: float) -> void:
-    if Input.is_action_just_pressed("ui_accept") and animation_player.is_playing():
-        const flash_point: float = 5.5
-        if animation_player.current_animation_position < flash_point:
-            animation_player.seek(flash_point)
+    if not animation_player.is_playing() or not Input.is_anything_pressed():
+        return
+
+    if animation_player.current_animation_position < animation_time_flash_point:
+        animation_player.seek(animation_time_flash_point)
+        return
+
+    if (animation_player.current_animation_position
+            > animation_time_near_after_flash_point
+        and animation_player.current_animation_position
+            < animation_time_near_end_point
+    ):
+        animation_player.seek(animation_time_near_end_point)


### PR DESCRIPTION
Repeat players may mash through the introduction now.

## Implementation Details

The first input was already coded to accept keyboard space and enter. So this PR opens up inputs to include clicks, and has a 0.5 second delay before allowing to skip the second half of the animation in case the first skip was an accident, the player still has some context of the title moving upward.

## Screenshot

![pr-117_introduction-skipped](https://github.com/user-attachments/assets/ebacc537-52f5-48cd-9f2c-1c5910159b61)
_**Screenshot 1:** Screenshot after the first skip lead to the fading in subtitle._