### PR TITLE
Engine Update - Equivalently Upgrade to Latest Godot 4.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Open source resources used:
 Coded using the [Godot](https://godotengine.org) game engine.
 
 The original game jam version, tagged as `ld56-submission` and [hosted on itch.io](https://nbumgardner.itch.io/tusk), runs on Godot version 4.3.
-The latest stable `main` code branch runs on Godot version 4.6.
+The latest stable `main` code branch runs on Godot version 4.7.
 
 ### License
 This game's code is open-source under the MIT License.

--- a/game/assets/art/transport/Tusk_Sprite_Frames.tres
+++ b/game/assets/art/transport/Tusk_Sprite_Frames.tres
@@ -61,7 +61,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_6sghq")
 }],
-"loop": true,
+"loop": 1,
 "name": &"default",
 "speed": 5.0
 }, {
@@ -84,7 +84,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_gtn2p")
 }],
-"loop": true,
+"loop": 1,
 "name": &"moving_bumpy",
 "speed": 5.0
 }, {
@@ -107,7 +107,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_v4lhq")
 }],
-"loop": true,
+"loop": 1,
 "name": &"moving_smooth",
 "speed": 5.0
 }]

--- a/game/project.godot
+++ b/game/project.godot
@@ -16,7 +16,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 
 config/name="LD 56"
 run/main_scene="res://src/start_menu/StartMenu.tscn"
-config/features=PackedStringArray("4.6", "GL Compatibility")
+config/features=PackedStringArray("4.7", "GL Compatibility")
 config/icon="res://icon.svg"
 
 [audio]


### PR DESCRIPTION
Upgrade from Godot 4.6 to 4.7 so it is easier to locally run and make enhancements to the game.